### PR TITLE
Feature/update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -731,46 +731,51 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@comunica/actor-abstract-bindings-hash": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.4.4.tgz",
+      "integrity": "sha512-SgT7+WAzas/S8OyGs018KRAkCZbCo9Xo1YQTMf2JmL30wLc8iR8vrtlBgd/noyesd9iOFKiroyrR19Zm3/qnpQ=="
+    },
     "@comunica/actor-abstract-mediatyped": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.2.0.tgz",
-      "integrity": "sha512-tSrTf+s/warqIrmh1SbbuHP+wfRCwNi8hDV1P0mSRbpnHyrKWZRtNa+2HISiTOh/0SJCzi/IIY0ufts2qzPZHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.4.0.tgz",
+      "integrity": "sha512-30WSiLjDaZ7mkeRzbsoW91UHaWtfgYH54W7qIP9osntfFUQq6KbYGsmlnsDPSva+cmGralAb7g3HMqErBeFHgQ==",
       "requires": {
         "lodash.mapvalues": "^4.6.0"
       }
     },
     "@comunica/actor-abstract-path": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.2.0.tgz",
-      "integrity": "sha512-IrZBIGeAzk/6slKMZ57TvkHmBIG+zpUrZowLwYJissyuCIlSpnMv+fufgXVptwNIiduDNcqp/aHYu2rburLZxg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.4.5.tgz",
+      "integrity": "sha512-NDFaA880vcpxnRZaZrOKi/8jN7bYc0cx07PZhMP59BcIvaLJA6V7BuJNegQeeKDPA0K/mkMsWztq6nsvLYHkuQ==",
       "requires": {
-        "@rdfjs/data-model": "^1.0.0",
-        "asynciterator": "^2.0.0",
-        "rdf-string": "^1.2.0",
-        "sparqlalgebrajs": "^1.1.0"
+        "@rdfjs/data-model": "^1.1.1",
+        "asynciterator": "^2.0.1",
+        "rdf-string": "^1.3.1",
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-context-preprocess-rdf-source-identifier": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-rdf-source-identifier/-/actor-context-preprocess-rdf-source-identifier-1.2.0.tgz",
-      "integrity": "sha512-mqg0vvFf7q1IfGcutahfshwPmIHfDsqw7pssfLEGGPRvMnckfRxpltCJiE5bkySQ6bYCteRdGeJKfPZdB5Al5A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-rdf-source-identifier/-/actor-context-preprocess-rdf-source-identifier-1.4.0.tgz",
+      "integrity": "sha512-NdR1XNjFyYg+e2L+YScKFEl7Y4MdDd/9cd8catsEqxymxLVmQjRVltP7QhAt5TPvake5pQmynpl547SwYeg4Rg==",
       "requires": {
         "asyncreiterable": "^1.1.0"
       }
     },
     "@comunica/actor-http-memento": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.2.0.tgz",
-      "integrity": "sha512-K4fw+IuY1R8pPrzzfjW+wLPxmYALiKRJCUgxg2qN2MMPwEJm3FNxiEq68fYy/i2BddLPQWk/gEnI0YZlhtiapQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.4.0.tgz",
+      "integrity": "sha512-MhOlPeAo9U3VRRIMo/giCJo6Mhmc/g8EPCfT0bo5WHvMdO+Mpepm9QSxvhC0CkqOf62mb58pddzCj7SeehOkYQ==",
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "parse-link-header": "^1.0.1"
       }
     },
     "@comunica/actor-http-native": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.2.0.tgz",
-      "integrity": "sha512-ymdR/iU78wLlpgMmvAPkisza+KMMIoE9jDVp+pm3+iBGNJkiXPWb1sWyyqU937f4GsvCOpdYhU7cdLWy+Rfqww==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.4.4.tgz",
+      "integrity": "sha512-Gk8gqd8JBHWzT/M8IOuKdOR9toYmIhim0lx6F4uNDAEIxjvNp2e6pKMpskeHRwJvi4TKNMrv+k/k1AhwhdTYxw==",
       "requires": {
         "follow-redirects": "^1.5.1",
         "isomorphic-fetch": "^2.2.1",
@@ -778,358 +783,443 @@
       }
     },
     "@comunica/actor-init-sparql": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.3.0.tgz",
-      "integrity": "sha512-8LkjkOvl6xh1XaYNycK8D41N60f694ncTub/FzsbGRx99ueUv9EStnjjc9SKzPjUIp7wshaK2r6NuFuT/9lVbw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.5.0.tgz",
+      "integrity": "sha512-KJZFvw249N0M84TKgRmcvlg3xme9gHxmJljKjPeKZLHIiPKE87Ce4CR/Ed45nuKI2X5UxWsDskaHNUPiFfsbxA==",
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.2.0",
-        "@comunica/actor-context-preprocess-rdf-source-identifier": "^1.2.0",
-        "@comunica/actor-http-memento": "^1.2.0",
-        "@comunica/actor-http-native": "^1.2.0",
-        "@comunica/actor-query-operation-ask": "^1.2.0",
-        "@comunica/actor-query-operation-bgp-empty": "^1.2.0",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.2.0",
-        "@comunica/actor-query-operation-bgp-single": "^1.2.0",
-        "@comunica/actor-query-operation-construct": "^1.2.0",
-        "@comunica/actor-query-operation-describe-subject": "^1.2.0",
-        "@comunica/actor-query-operation-distinct-hash": "^1.2.0",
-        "@comunica/actor-query-operation-filter-direct": "^1.2.0",
-        "@comunica/actor-query-operation-from-quad": "^1.2.0",
-        "@comunica/actor-query-operation-join": "^1.2.0",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.2.0",
-        "@comunica/actor-query-operation-orderby-direct": "^1.2.0",
-        "@comunica/actor-query-operation-path-alt": "^1.2.1",
-        "@comunica/actor-query-operation-path-inv": "^1.2.1",
-        "@comunica/actor-query-operation-path-link": "^1.2.1",
-        "@comunica/actor-query-operation-path-nps": "^1.2.1",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.2.1",
-        "@comunica/actor-query-operation-path-seq": "^1.2.1",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.2.1",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.2.1",
-        "@comunica/actor-query-operation-project": "^1.2.0",
-        "@comunica/actor-query-operation-quadpattern": "^1.2.0",
-        "@comunica/actor-query-operation-service": "^1.2.1",
-        "@comunica/actor-query-operation-slice": "^1.2.0",
-        "@comunica/actor-query-operation-sparql-endpoint": "^1.3.0",
-        "@comunica/actor-query-operation-union": "^1.2.0",
-        "@comunica/actor-query-operation-values": "^1.2.0",
-        "@comunica/actor-rdf-dereference-http-parse": "^1.2.0",
-        "@comunica/actor-rdf-dereference-paged-next": "^1.2.0",
-        "@comunica/actor-rdf-join-nestedloop": "^1.2.0",
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.2.0",
-        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.2.0",
-        "@comunica/actor-rdf-metadata-primary-topic": "^1.2.0",
-        "@comunica/actor-rdf-metadata-triple-predicate": "^1.2.0",
-        "@comunica/actor-rdf-parse-jsonld": "^1.2.0",
-        "@comunica/actor-rdf-parse-n3": "^1.2.0",
-        "@comunica/actor-rdf-parse-rdfxml": "^1.3.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.2.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-file": "^1.2.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-qpf": "^1.2.0",
-        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.2.1",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.2.0",
-        "@comunica/actor-rdf-serialize-n3": "^1.2.0",
-        "@comunica/actor-rdf-source-identifier-file-content-type": "^1.2.0",
-        "@comunica/actor-rdf-source-identifier-hypermedia-qpf": "^1.2.0",
-        "@comunica/actor-rdf-source-identifier-sparql": "^1.2.0",
-        "@comunica/actor-sparql-parse-algebra": "^1.2.0",
-        "@comunica/actor-sparql-parse-graphql": "^1.2.1",
-        "@comunica/actor-sparql-serialize-json": "^1.2.0",
-        "@comunica/actor-sparql-serialize-rdf": "^1.2.0",
-        "@comunica/actor-sparql-serialize-simple": "^1.2.0",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.2.0",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.2.0",
-        "@comunica/actor-sparql-serialize-stats": "^1.2.0",
-        "@comunica/actor-sparql-serialize-table": "^1.2.0",
-        "@comunica/actor-sparql-serialize-tree": "^1.3.0",
-        "@comunica/bus-context-preprocess": "^1.2.0",
-        "@comunica/bus-http": "^1.2.0",
-        "@comunica/bus-init": "^1.2.0",
-        "@comunica/bus-query-operation": "^1.2.0",
-        "@comunica/bus-rdf-dereference": "^1.2.0",
-        "@comunica/bus-rdf-dereference-paged": "^1.2.0",
-        "@comunica/bus-rdf-join": "^1.2.0",
-        "@comunica/bus-rdf-metadata": "^1.2.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.2.0",
-        "@comunica/bus-rdf-parse": "^1.2.0",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.2.0",
-        "@comunica/bus-rdf-serialize": "^1.2.0",
-        "@comunica/bus-rdf-source-identifier": "^1.2.0",
-        "@comunica/bus-sparql-parse": "^1.2.0",
-        "@comunica/bus-sparql-serialize": "^1.2.0",
-        "@comunica/core": "^1.2.0",
-        "@comunica/logger-pretty": "^1.2.0",
-        "@comunica/logger-void": "^1.2.0",
-        "@comunica/mediator-combine-pipeline": "^1.2.0",
-        "@comunica/mediator-combine-union": "^1.2.0",
-        "@comunica/mediator-number": "^1.2.0",
-        "@comunica/mediator-race": "^1.2.0",
-        "@comunica/runner": "^1.2.0",
-        "@comunica/runner-cli": "^1.2.0",
+        "@comunica/actor-abstract-bindings-hash": "^1.4.4",
+        "@comunica/actor-abstract-mediatyped": "^1.4.0",
+        "@comunica/actor-context-preprocess-rdf-source-identifier": "^1.4.0",
+        "@comunica/actor-http-memento": "^1.4.0",
+        "@comunica/actor-http-native": "^1.4.4",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^1.5.0",
+        "@comunica/actor-query-operation-ask": "^1.4.4",
+        "@comunica/actor-query-operation-bgp-empty": "^1.4.4",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.4.5",
+        "@comunica/actor-query-operation-bgp-single": "^1.4.4",
+        "@comunica/actor-query-operation-construct": "^1.4.4",
+        "@comunica/actor-query-operation-describe-subject": "^1.4.4",
+        "@comunica/actor-query-operation-distinct-hash": "^1.4.4",
+        "@comunica/actor-query-operation-extend": "^1.5.0",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.5.0",
+        "@comunica/actor-query-operation-from-quad": "^1.4.5",
+        "@comunica/actor-query-operation-join": "^1.4.4",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.5.0",
+        "@comunica/actor-query-operation-minus": "^1.4.4",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.5.0",
+        "@comunica/actor-query-operation-path-alt": "^1.4.5",
+        "@comunica/actor-query-operation-path-inv": "^1.4.5",
+        "@comunica/actor-query-operation-path-link": "^1.4.5",
+        "@comunica/actor-query-operation-path-nps": "^1.4.5",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.4.5",
+        "@comunica/actor-query-operation-path-seq": "^1.4.5",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.4.5",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.4.5",
+        "@comunica/actor-query-operation-project": "^1.4.4",
+        "@comunica/actor-query-operation-quadpattern": "^1.4.5",
+        "@comunica/actor-query-operation-reduced-hash": "^1.4.5",
+        "@comunica/actor-query-operation-service": "^1.4.4",
+        "@comunica/actor-query-operation-slice": "^1.4.4",
+        "@comunica/actor-query-operation-sparql-endpoint": "^1.4.6",
+        "@comunica/actor-query-operation-union": "^1.4.4",
+        "@comunica/actor-query-operation-values": "^1.4.4",
+        "@comunica/actor-rdf-dereference-http-parse": "^1.4.2",
+        "@comunica/actor-rdf-dereference-paged-next": "^1.4.5",
+        "@comunica/actor-rdf-join-nestedloop": "^1.4.4",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.4.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.4.0",
+        "@comunica/actor-rdf-metadata-primary-topic": "^1.4.0",
+        "@comunica/actor-rdf-metadata-triple-predicate": "^1.4.0",
+        "@comunica/actor-rdf-parse-jsonld": "^1.4.5",
+        "@comunica/actor-rdf-parse-n3": "^1.4.3",
+        "@comunica/actor-rdf-parse-rdfxml": "^1.4.3",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.4.5",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.4.5",
+        "@comunica/actor-rdf-resolve-quad-pattern-file": "^1.4.5",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.4.6",
+        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.4.5",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.4.0",
+        "@comunica/actor-rdf-serialize-n3": "^1.4.3",
+        "@comunica/actor-rdf-source-identifier-file-content-type": "^1.4.0",
+        "@comunica/actor-rdf-source-identifier-hypermedia-qpf": "^1.4.0",
+        "@comunica/actor-rdf-source-identifier-sparql": "^1.4.0",
+        "@comunica/actor-sparql-parse-algebra": "^1.4.5",
+        "@comunica/actor-sparql-parse-graphql": "^1.4.3",
+        "@comunica/actor-sparql-serialize-json": "^1.4.4",
+        "@comunica/actor-sparql-serialize-rdf": "^1.4.4",
+        "@comunica/actor-sparql-serialize-simple": "^1.4.4",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.4.4",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.4.4",
+        "@comunica/actor-sparql-serialize-stats": "^1.4.4",
+        "@comunica/actor-sparql-serialize-table": "^1.4.4",
+        "@comunica/actor-sparql-serialize-tree": "^1.4.4",
+        "@comunica/bus-context-preprocess": "^1.4.0",
+        "@comunica/bus-http": "^1.4.0",
+        "@comunica/bus-init": "^1.4.0",
+        "@comunica/bus-optimize-query-operation": "^1.5.0",
+        "@comunica/bus-query-operation": "^1.4.4",
+        "@comunica/bus-rdf-dereference": "^1.4.0",
+        "@comunica/bus-rdf-dereference-paged": "^1.4.0",
+        "@comunica/bus-rdf-join": "^1.4.4",
+        "@comunica/bus-rdf-metadata": "^1.4.0",
+        "@comunica/bus-rdf-metadata-extract": "^1.4.0",
+        "@comunica/bus-rdf-parse": "^1.4.2",
+        "@comunica/bus-rdf-resolve-hypermedia": "^1.4.5",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.4.5",
+        "@comunica/bus-rdf-serialize": "^1.4.0",
+        "@comunica/bus-rdf-source-identifier": "^1.4.0",
+        "@comunica/bus-sparql-parse": "^1.4.0",
+        "@comunica/bus-sparql-serialize": "^1.4.4",
+        "@comunica/core": "^1.4.0",
+        "@comunica/logger-pretty": "^1.4.0",
+        "@comunica/logger-void": "^1.4.0",
+        "@comunica/mediator-combine-pipeline": "^1.4.0",
+        "@comunica/mediator-combine-union": "^1.4.0",
+        "@comunica/mediator-number": "^1.4.1",
+        "@comunica/mediator-race": "^1.4.0",
+        "@comunica/runner": "^1.4.4",
+        "@comunica/runner-cli": "^1.4.4",
         "asyncreiterable": "^1.1.0",
         "minimist": "^1.2.0",
         "negotiate": "^1.0.1",
-        "rdf-string": "^1.1.1",
-        "rdf-terms": "^1.1.0",
+        "rdf-string": "^1.3.1",
+        "rdf-terms": "^1.4.0",
         "streamify-string": "^1.0.1"
       }
     },
+    "@comunica/actor-optimize-query-operation-join-bgp": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.5.0.tgz",
+      "integrity": "sha512-PBMbOahhuHqUqTjqqqqibS6SorJGihxTPSEiSpJ6cAENWXwKqLzc1/M+5p4ToGOK1t7JrlsPcwbBmxqlWZLySg==",
+      "requires": {
+        "sparqlalgebrajs": "^1.4.0"
+      }
+    },
     "@comunica/actor-query-operation-ask": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.2.0.tgz",
-      "integrity": "sha512-WeyXuYcksjNEmGn/hYMh/oAJgjK1RF7XyGr/KUZnDpgxZ4CSpvyZMlUmedP4YayYMgsxvK49aDcOBDFcz7TU7g=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.4.4.tgz",
+      "integrity": "sha512-SXXik/wfFL8fQaeZ6AtMTi3YOprWsWa9p+bVqf+94fLZV1a0X2EUXUjSbLUm4EgoIW9q23zbqkuBu8hv1VR2NA=="
     },
     "@comunica/actor-query-operation-bgp-empty": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.2.0.tgz",
-      "integrity": "sha512-ALjXAoPZ+ZNP1/+xSefIOX+CqOhdNdE/Ti8SZw6re/EskkVtiw73rboypNCYWDP0+N9IpO5inx54VgLDpKIv9A==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.4.4.tgz",
+      "integrity": "sha512-TcgsQT8RPZkOJrzWme8EnEyACOpLPXaL+20iGxYYkfEO2dprz9nDNobOBCiCVUU4muZPUEkKOK6JDAFTlk26ww==",
       "requires": {
-        "asynciterator": "^2.0.0"
+        "asynciterator": "^2.0.1"
       }
     },
     "@comunica/actor-query-operation-bgp-left-deep-smallest": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.2.0.tgz",
-      "integrity": "sha512-GkIZoB9KWaIWfeHlXvyq9K+ITQu6MRU8/jvzAu0PZBwGxlg5cGaZ6BX+MwuUOqJTtNTkno51jmkzZkWsVuKfDg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.4.5.tgz",
+      "integrity": "sha512-5IVoDX0upYMM0p8ibnxeqtrnIvhJPTitsEB240Jr+cMHqNYLwcSncwh9pU7tGKtqhzYgeYZKXEp0Ju+9aviAKQ==",
       "requires": {
         "asynciterator-promiseproxy": "^2.0.0",
         "lodash.uniq": "^4.5.0",
-        "rdf-string": "^1.1.1",
-        "rdf-terms": "^1.1.0"
+        "rdf-string": "^1.3.1",
+        "rdf-terms": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-bgp-single": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.2.0.tgz",
-      "integrity": "sha512-gKD6UrRzCxOMNjBojJlWqIQM8wnk5KU0/FIFC7LxkUPaTDkLhj1NLL93wkk2+J2snWkBgT1Mghf8F9fdttKRhQ=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.4.4.tgz",
+      "integrity": "sha512-3S9S5q/yICpSn4WsqvEPUYx1+Tm/UAx0yzYK+B6nj4Ip/+ZRF67NeZSGPbH1N97m9jBAJIimptAodQocU9D2yA=="
     },
     "@comunica/actor-query-operation-construct": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.2.0.tgz",
-      "integrity": "sha512-CIWbEufB7twVaxpxuDZ6KIX+Oxv9hRwmFngBTZPvP1faQ4tgAZidL6q6WSne+CNkJYobnprtz2p/FTkFUeekHw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.4.4.tgz",
+      "integrity": "sha512-HD32kHIbPgi+ifko0T7tD5dyxHomIXxAD/ud1EJLkKMkl7/4AQXdM7AdcfhUAz57QS3yFRebED2c2hGTzuCDsg==",
       "requires": {
-        "@rdfjs/data-model": "^1.1.0",
-        "asynciterator": "^2.0.0",
-        "rdf-terms": "^1.1.0"
+        "@rdfjs/data-model": "^1.1.1",
+        "asynciterator": "^2.0.1",
+        "rdf-terms": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-describe-subject": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.2.0.tgz",
-      "integrity": "sha512-oKAXGoDrqg6y/YIK2vd47hSq/KVOoEuJvNj23aCtzZ4YX8dqF79h8zWMttu9Zia5UJ1RLZxF6vy016ZIwEy/Ow==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.4.4.tgz",
+      "integrity": "sha512-EAGX3KvhuQPpxatQTfuy1FXziTBQe04bcpaETIKqdE9zrxwTsSpp0IjoOtUJZU8VFHx0OOr8GqfD7mrRA6x/rg==",
       "requires": {
-        "@comunica/actor-query-operation-union": "^1.2.0",
-        "@rdfjs/data-model": "^1.1.0",
-        "asynciterator-union": "^2.1.0"
+        "@comunica/actor-query-operation-union": "^1.4.4",
+        "@rdfjs/data-model": "^1.1.1",
+        "asynciterator-union": "^2.1.1"
       }
     },
     "@comunica/actor-query-operation-distinct-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.2.0.tgz",
-      "integrity": "sha512-Dy4MRgV55mhOdhm95yyklhngiYd0B0vFLze1jGMxP5aFgDmzYpK3ZZTKZAaAfLkvjN8t8kYmfH060FWfV2Y37Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.4.4.tgz",
+      "integrity": "sha512-CNSlO8OmoQy3zaBokvSlL3tqUmntcII9M7Y4Mzar9DxhSYeOB9k8uEIy5loKWze9u1/DQnOs6C/3YuxlopG1xg==",
       "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.4.4",
         "json-stable-stringify": "^1.0.1"
       }
     },
-    "@comunica/actor-query-operation-filter-direct": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-direct/-/actor-query-operation-filter-direct-1.2.0.tgz",
-      "integrity": "sha512-YiSo9vxUncGi7dpd7eXdSAu5v5lbRyN80EwwmaWsUX3iosYsjPHe0hooJVL3zjwc8uja5WyTP3rcUDMQMOdeSg==",
+    "@comunica/actor-query-operation-extend": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.5.0.tgz",
+      "integrity": "sha512-EvkydjFNoWywHXv7XSI1lYnqzP9ie7M22/DwQ5bzf/mXonvIc+orCVvSnfESD0pY0hJfQvg+2kdcWhB6bl+IOA==",
       "requires": {
-        "rdf-string": "^1.1.1"
+        "sparqlee": "0.0.1"
+      }
+    },
+    "@comunica/actor-query-operation-filter-sparqlee": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.5.0.tgz",
+      "integrity": "sha512-vJljjbr7w9kwt5cAgBU+tilsGZsyreN38C3ssfJaR/trI+7RKz3FHCIR7vfq1VIWAFzwZFFI//sh3oKcSSkD+w==",
+      "requires": {
+        "sparqlee": "0.0.1"
       }
     },
     "@comunica/actor-query-operation-from-quad": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.2.0.tgz",
-      "integrity": "sha512-jorN0Gh18xttuSXYNoMp2bQqnv2TCHFkORp5aEKFuYNVQfrsSDp7C+gv5BtdfZC1HZtmA9L9AZevQlt/qC5l4A==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.4.5.tgz",
+      "integrity": "sha512-TG7eDrrQ1XS+7Ut5pPExikdTipJSJICEmA0Nw+B7H5WjKEdND/GeMsvqLqk+u1AiHHJiR3kfjso5fEnzM4OUyw==",
       "requires": {
         "lodash.find": "^4.6.0",
-        "sparqlalgebrajs": "^1.1.0"
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-join": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.2.0.tgz",
-      "integrity": "sha512-S7TkYhUpB4FHvJpjyEVyY8P08Wnemfq6FIc6/YrifMNWiYS9oEZyg9NmrZTdAcjpN15SwhAoYTXCi/NkObD1jg=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.4.4.tgz",
+      "integrity": "sha512-xTxusuDuLbE2mSxxmtPUInAkuKwcPgTkCZj7jif/j934qdo7Ar1lIZwQJL0AwgOdmMODn/9Z6/oiIrLMR/xKBA=="
     },
     "@comunica/actor-query-operation-leftjoin-nestedloop": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.2.0.tgz",
-      "integrity": "sha512-4BFyxpD9e3wfVyfZmCe3VdkNufCGvi4Mkla+ytEZgGuU+S2G5Xo4s7sQVhxiCTn+p1aN1N9rgojZszrauTi/nQ=="
-    },
-    "@comunica/actor-query-operation-orderby-direct": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-direct/-/actor-query-operation-orderby-direct-1.2.0.tgz",
-      "integrity": "sha512-gliUnAhlIxnGJcnrsZoodpfICvWinTFj1g55TV+9VprAoxEtbinCmBBGHY7l4874AUnMxfQe0jmLOW6mbiZX9Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.5.0.tgz",
+      "integrity": "sha512-5BMiG/dwmSwrvsXLeoAJO2kxWovWxL3ArdsCrVst2v44icJmtwpmqwYGzTtNY7GJL/2hBkeJab38gM8wcFEuhQ==",
       "requires": {
-        "rdf-string": "^1.1.1"
+        "sparqlee": "0.0.1"
+      }
+    },
+    "@comunica/actor-query-operation-minus": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.4.4.tgz",
+      "integrity": "sha512-eB3bNyKxtPZu73zgg9fuKbtQERHIzUX3Y7RTCmejQ77wZo1SwEsIlEaMoudqX1+nlj31fwtqb/NtYbR6X0Axxg==",
+      "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.4.4",
+        "asynciterator-promiseproxy": "^2.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-orderby-sparqlee": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.5.0.tgz",
+      "integrity": "sha512-YVw62vpIYXPWD8f9yyL1J0v4uddLvpvPbfOt8M6Tfn0fLJplCuDI42f/euDumZn166ui1ekk9TYLTlqU9h4P7g==",
+      "requires": {
+        "rdf-string": "^1.3.1",
+        "sparqlee": "0.0.1"
       }
     },
     "@comunica/actor-query-operation-path-alt": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.2.1.tgz",
-      "integrity": "sha512-IE2LRZn3G9HgCquK/K0Ry/NPs9S/OP+cfKaoAf/LaYUBc6pZ9IC3BltUfU7vEXK+No4ljmwmNPztVgcrpWpr0w==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.4.5.tgz",
+      "integrity": "sha512-3x3GLHISOtYwfHBudCz6TZGQNqB0jnnV/CYRIB61gnzLTDaI5Ts1bBNRklNQ77kjENq9EA02qOxXQnBQzbGQNg==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.2.0",
-        "asynciterator-union": "^2.1.0",
-        "lodash.uniq": "^4.5.0"
+        "@comunica/actor-abstract-path": "^1.4.5",
+        "asynciterator-union": "^2.1.1",
+        "lodash.uniq": "^4.5.0",
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-inv": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.2.1.tgz",
-      "integrity": "sha512-RbgehsrkUaFy1SFrKrW2BAfGccGinIhvxrtCXLvOS5wzB/4N/PzLTKQRYlI0/1dQyIVQIvdNNKOKRe3QzHhuiw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.4.5.tgz",
+      "integrity": "sha512-Ex/w1omPPo/HPqLPP1D+Weof60AEs5sYUe5PBaUwHnAiJycqyD9fMvFFgl08N5vg/EmaVZB0d5dgGSzgV5WE2A==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.2.0"
+        "@comunica/actor-abstract-path": "^1.4.5"
       }
     },
     "@comunica/actor-query-operation-path-link": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.2.1.tgz",
-      "integrity": "sha512-EZ+36RGW6fQ/NgiBkf9jLWIXNRHDXCzPioIcFYDIO08f1M6092+Kdt6VHOlU+799G3lyxnoMesWniDhtixpcTA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.4.5.tgz",
+      "integrity": "sha512-soXrhOH0Azc0QNhnlnFfqxMXhba2GNEDV3wOXWxQNgf1mc2SV1kkaTHzBgbWuEL3I4wzzMp2EbrWdZSzanPfxw==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.2.0"
+        "@comunica/actor-abstract-path": "^1.4.5",
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-nps": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.2.1.tgz",
-      "integrity": "sha512-ONDnuTphgUpRqIZFPzGzKcmNM2fef8poNBn7rQE0eSMOyBBBzzBN7AhmRs9DfdJmK/ZG2Vbh5vaaNyI+ahCZ6Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.4.5.tgz",
+      "integrity": "sha512-vHl9GznWT0pW+KR/f9INfDo119OBjO1FLZxPlwWivo273WQtuVFfWQkL3iZToGIyUy7Aq3pLSh5kcvtRMIGj9w==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.2.0"
+        "@comunica/actor-abstract-path": "^1.4.5",
+        "rdf-string": "^1.3.1",
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-one-or-more": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.2.1.tgz",
-      "integrity": "sha512-4LDALADiw2wLzBmMxLxH0ESuWIjstQV9TJjckDFNjuRfWMi+pmo6zvGf1uMl56ifsFVzM16IM1QgSewpZgSm/Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.4.5.tgz",
+      "integrity": "sha512-Tm+tdT4Zkvn/JZEFZ+X2nUc/nNFmKV1t+I3SaPSJVv3Z2/2CyjtA4SsuWaugo3IW5N9uDtIeOxGy4mhopo8myQ==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.2.0",
-        "asynciterator": "^2.0.0",
+        "@comunica/actor-abstract-path": "^1.4.5",
+        "asynciterator": "^2.0.1",
         "asynciterator-promiseproxy": "^2.0.0",
-        "rdf-string": "^1.2.0"
+        "rdf-string": "^1.3.1",
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-seq": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.2.1.tgz",
-      "integrity": "sha512-bwkucLMMwashHKOtbI77MhYYng5HHhCsB1HNMsggmopLqIjNBGRxeUR3BwrmNT74fV5XgQRJlhUhjWaxmSjkyg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.4.5.tgz",
+      "integrity": "sha512-ihPQFDFPgDGYsBrwYcsJLv0hyDrJDYda6Dg17mnEtKGtk/TBn65Ev1A+YX1B3DPl5uUDWcEwrwZuIHzDrdssUw==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.2.0",
-        "rdf-string": "^1.2.0"
+        "@comunica/actor-abstract-path": "^1.4.5",
+        "rdf-string": "^1.3.1",
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.2.1.tgz",
-      "integrity": "sha512-UdzcGUE5HZhduLhDcUbBR3gYyzzVXH0HiGso09/TVeNW8IMSqmBjHSVjA4/tqCow12wSVd/13Ap+l52TS9VvUg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.4.5.tgz",
+      "integrity": "sha512-RB+uoxnuvfCpoL3dzzlULrwqGfYPRQ4gSKjTKtkPm3yQEKzqoFp9q6HxGIilk8l1MddEnaHd30PnN/l3csarIg==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.2.0",
-        "rdf-string": "^1.2.0"
+        "@comunica/actor-abstract-path": "^1.4.5",
+        "rdf-string": "^1.3.1",
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.2.1.tgz",
-      "integrity": "sha512-O+kEOzCSJDJtpvEAN2H07gPniTWe89JmpB0cqJx/jN/fwkCEBNMvSW2SCcktUTqxFqOO1VbXCwbkLk7Pw8AtXw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.4.5.tgz",
+      "integrity": "sha512-j4cTlPNDRKUybM5L4Uzqlid4Z4MhxwDhpGqF61v3Xs8icBO4F9JQGmgqNZy/CmT0QSdLycVfX/ubcNg69fb50w==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.2.0",
-        "asynciterator": "^2.0.0",
-        "rdf-string": "^1.2.0"
+        "@comunica/actor-abstract-path": "^1.4.5",
+        "asynciterator": "^2.0.1",
+        "rdf-string": "^1.3.1"
       }
     },
     "@comunica/actor-query-operation-project": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.2.0.tgz",
-      "integrity": "sha512-s6NrPRe26nbZP+p45piVdoGOtvbxImuz3LDSxFE94dYl40kL61Dk1YPIwJ3yVCoiCznCPQmgG4UaeIoYBE1JqA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.4.4.tgz",
+      "integrity": "sha512-3iDB23M5/cYlyK+Ce1T9HuhKTT2e3iQGyRpnoL83PWa3NrRNy6J/5MYbKD6rB66cL28XSMLPfHghG7A2kpvv3g==",
       "requires": {
-        "rdf-string": "^1.1.1"
+        "rdf-string": "^1.3.1"
       }
     },
     "@comunica/actor-query-operation-quadpattern": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.2.0.tgz",
-      "integrity": "sha512-WUwTd5JMBRLQwUdKPnc8PIWFYt/KZFmGkBZzTV2Nvyb4DdoZ9YGLflP2Ln1olsw5MPsudvRvSYAqgStFNWGsBw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.4.5.tgz",
+      "integrity": "sha512-lKX0hJUgiQXpkof+P6s7IWMRQYU7qwKvjcL9JOAwMAcYoQfZFOjnV3WwBl8H1/MqMeuMTckccYnsblrvlBqmxg==",
       "requires": {
         "asynciterator-promiseproxy": "^2.0.0",
-        "rdf-string": "^1.1.1",
-        "rdf-terms": "^1.1.0"
+        "rdf-string": "^1.3.1",
+        "rdf-terms": "^1.4.0"
+      }
+    },
+    "@comunica/actor-query-operation-reduced-hash": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.4.5.tgz",
+      "integrity": "sha512-Nl8Uv1gRTAeZxvLOW6hlTUV2tm6qQtkanUgjxqNjoLSRTmOe7JqcQiKZg9vjgW82d8HUXYmzgvzMMezm3DAkaQ==",
+      "requires": {
+        "@comunica/actor-abstract-bindings-hash": "^1.4.4",
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
       }
     },
     "@comunica/actor-query-operation-service": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.2.1.tgz",
-      "integrity": "sha512-myp71zbI/sVzVxGZ4GixAF3SARR1jLMYB5TjaFNlTjah84tYeu1tNKPG44K+N6Hrb0VCTAHvwMjXH3PXFDqUmA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.4.4.tgz",
+      "integrity": "sha512-NsEwoFrvHbRtJj+G9ZsmtPxISb+zmCjaLyGFHkpfT4NnqAeASNZWlakckRXm4mNSl3QLKvkF8rRlzVRxG+NGVQ==",
       "requires": {
-        "asynciterator": "^2.0.0"
+        "asynciterator": "^2.0.1"
       }
     },
     "@comunica/actor-query-operation-slice": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.2.0.tgz",
-      "integrity": "sha512-wBC1FkGnJH6jJr4BixxPBa3ui+gkTDuuJzM0QRxz5yivt/q5VWKkCrUbLBevqKmh66dWSO/u8lnJm14m0+U+4A=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.4.4.tgz",
+      "integrity": "sha512-Ta9l2eOqgC1i2hOONWnlaUJ5EtDKEFJPV7G3zC7XCl0V4XBKXyMqpkXy9LXOJbPoMP1VvHdxoLNJ05xOSjHvtQ=="
     },
     "@comunica/actor-query-operation-sparql-endpoint": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.3.0.tgz",
-      "integrity": "sha512-Zjg/sIQi7xlGL9EY+JVloIgz86QgiOJYKHPMWV5Op711267g/NBSNNsDZk63jqbI70I0r6MSYVsm8ba0kOa9ow==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.4.6.tgz",
+      "integrity": "sha512-9c2QV6359yvFgmZXgDO93iM6g7e3kqqHgSTKJwnzjb4HKQoYoZSvX+/5mDiNE6aCdEVaPzdqpwDfRKF2N6Os8g==",
       "requires": {
+        "@comunica/utils-datasource": "^1.4.5",
         "arrayify-stream": "^1.0.0",
-        "asynciterator": "^2.0.0",
-        "fetch-sparql-endpoint": "^1.3.3",
-        "rdf-string": "^1.1.1",
-        "rdf-terms": "^1.1.0",
-        "sparqlalgebrajs": "^1.1.0"
+        "asynciterator": "^2.0.1",
+        "fetch-sparql-endpoint": "^1.4.0",
+        "rdf-string": "^1.3.1",
+        "rdf-terms": "^1.4.0",
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-union": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.2.0.tgz",
-      "integrity": "sha512-vff4XVdGQUNoJF6dQ5oPEA4LyxS0XDAn74nAOlGz7BPwFD90gwScpXzYVm8m48Is2JcwKGyPXL8ceh4dcfT5og==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.4.4.tgz",
+      "integrity": "sha512-tCyYbT/0fKnmV3al2YSdytrfq9pgI5FrIW7nMKyFL5HiHQTmbDRPbCJxVeOq++gtRWVUG64p/RY2or8/OpCUeQ==",
       "requires": {
-        "asynciterator-union": "^2.1.0",
+        "asynciterator-union": "^2.1.1",
         "lodash.union": "^4.6.0"
       }
     },
     "@comunica/actor-query-operation-values": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.2.0.tgz",
-      "integrity": "sha512-OMX0sgyVsmKQwIPCauT3ncnRB5449dH5rYZEAyC7nvV/SLI0nrc2D9Dh6MKfSQSytsAuyXTKKeqGaHYE2TWOfQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.4.4.tgz",
+      "integrity": "sha512-xsutv0JdD1Xjxfvnf7KnJnV6DNv2+Gmb5nzy3KnDd5QJ8d/tB27dOR0jiS/K/sVJWlKQPZ8QMbritFh/WrB/Vg==",
       "requires": {
-        "asynciterator": "^2.0.0",
-        "rdf-string": "^1.1.1"
+        "asynciterator": "^2.0.1",
+        "rdf-string": "^1.3.1"
       }
     },
     "@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.2.0.tgz",
-      "integrity": "sha512-N7+HfSIQ47bUCWSOP6Efh5rHlLIpa95xdboVSENkJNOrDc5wzXfFMTJstWcIZ3Z3yHZWxGYFPVs6C0i/sfragA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.4.2.tgz",
+      "integrity": "sha512-2cKGrBY5cdkqV/puIdiR6625ANsDDrHSyqfOUuC4Ro3H2y65ieknZmC6ZKgQfD6Btg0WctKUMZD4sEFHBi3VFA==",
       "requires": {
         "node-web-streams": "^0.2.2"
       }
     },
     "@comunica/actor-rdf-dereference-paged-next": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-paged-next/-/actor-rdf-dereference-paged-next-1.2.0.tgz",
-      "integrity": "sha512-D/JJCGiJvSnRtb4jg3TZ+5R7Nz33s4gIPszTylk+/R9jV/ztVF1XPUIpOpLKPJfweu52zdrL136VysB4DT2MRw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-paged-next/-/actor-rdf-dereference-paged-next-1.4.5.tgz",
+      "integrity": "sha512-GJNBAB90XFExc5HKBs0oCUr749rHGQCjvZxWRH5CM6UFILfXvDt1GUvmWxWlVa4kcwqJQMvuVZioXvo9UqHMKg==",
       "requires": {
-        "asynciterator": "^2.0.0",
-        "lru-cache": "^4.1.1"
+        "asynciterator": "^2.0.1",
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
       }
     },
     "@comunica/actor-rdf-join-nestedloop": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.2.0.tgz",
-      "integrity": "sha512-ZN/DgvWWaZ+K3oQ8G5Qp5LH55s5uZcIBPoACIGAp6qvQUSPuhYzaX08YVkIJzyn4XTXQv/BegDdBYD1mvW/EHw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.4.4.tgz",
+      "integrity": "sha512-6RVl4lVGij1iElxBn3DeWE4u2K7N0KGMRi4OdjCycE+L8ihKvM0Mg/WtHf7qK5tyKMWIlVEUYDS1MvG5ZcaScw==",
       "requires": {
         "asyncjoin": "^0.3.0"
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-controls": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.2.0.tgz",
-      "integrity": "sha512-H3LYSSevbHapBsMoASIQmFwBGMFRny14FLlc3x8WBH1eryUrTeffROy6MPHwEoT6F71Y9gtXy4WDwZV3W+Fshw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.4.0.tgz",
+      "integrity": "sha512-haLNX+21KyrTTioMDrbDhG6SMfyUUYXLXoE8oZUwiGJOSzkkv2vcLmyaLEr+mgmalQ+LVLV/9ozmoWQxpjwA7w==",
       "requires": {
         "lodash.assign": "^4.2.0",
         "lodash.flatten": "^4.4.0",
@@ -1139,73 +1229,51 @@
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-count": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.2.0.tgz",
-      "integrity": "sha512-t7EUQF4347Q5W3qn7UyPFt49I9fXkuoCPHWfYhbn2l2AmUSGxHTeSbIB146GHadokvy+38s8kO2T7tTNHgjSfg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.4.0.tgz",
+      "integrity": "sha512-R1rvQBdzYApuikxdJj02rw+cAPzu9nXqJ8n+mTh7E8uXW1hFy9p+cDJBfTFOT4Ux/dNwxalTMz4y7WHdgRXlKQ=="
     },
     "@comunica/actor-rdf-metadata-primary-topic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.2.0.tgz",
-      "integrity": "sha512-H/JqaHcoRBPR4ij6DTAHT3lGxv+pZqxbUtGbVV8bci5zKwoWVUBk9cVIlq8Uv9BBCI6yAN/z/ubbsbIWcb3ZLw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.4.0.tgz",
+      "integrity": "sha512-yUdJBKwL53M1adz22y4gxGm2PtIudD2X1Jis9tfIrJV2p+qWLZUVmtpJYEmSvJjdoRoYe4LwGDZ209P2mUZTiQ=="
     },
     "@comunica/actor-rdf-metadata-triple-predicate": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-triple-predicate/-/actor-rdf-metadata-triple-predicate-1.2.0.tgz",
-      "integrity": "sha512-q40fsboe1CI+q+hFabDsxjWfuyFncHm4LQh+mGANb/mXrUYKQ6CuTAA5/CtUeDiCsHQsypfbzgLhtJCKUniaIw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-triple-predicate/-/actor-rdf-metadata-triple-predicate-1.4.0.tgz",
+      "integrity": "sha512-myi1b1Rz/5T22CBbklybJdqFTwUH4UJmPCP+YSUQ3JgJLnvBocRQW2PSNe7CgivWUyM/VGqoXD22SlaVaeIRZw=="
     },
     "@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.2.0.tgz",
-      "integrity": "sha512-TwDLgCgYolaAY2y/FgYQL7vlLwV5wOWQpZs35jU0qLaRpuKn4bB7MDTOTuji6zr0SQ1cHtRPh2+JXnX6uL9eSA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.4.5.tgz",
+      "integrity": "sha512-FVPTIkR+3oy/5oB1cEF4LwnKJgQVENJw+rxl9dSVOvCjuGhfebwGsvhG9g9tNgZgOCZ1TGiPaUUU+G0qv2OUuw==",
       "requires": {
-        "@rdfjs/data-model": "^1.1.0",
+        "@rdfjs/data-model": "^1.1.1",
         "jsonld": "^1.0.2",
-        "rdf-terms": "^1.2.0",
+        "rdf-terms": "^1.4.0",
         "stream-to-string": "^1.1.0"
       }
     },
     "@comunica/actor-rdf-parse-n3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.2.0.tgz",
-      "integrity": "sha512-PKvC86yP9/7+3HYh3tv/ccqVJR63sx9rotst6HPmnJCcPZxwcyznEpTJoiKuUucba83A+S7IfnxRl4nNp0A/Bg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.4.3.tgz",
+      "integrity": "sha512-DyblIe8G06AuPJ7LZnZGU9ngCZZX/10LvN3dGtDu0lsshSezXVnkF8P/If0CM13uYyXUoQ2RdQgi+TO/TaLSaQ==",
       "requires": {
-        "n3": "1.0.0-beta.2"
+        "n3": "^1.0.0"
       }
     },
     "@comunica/actor-rdf-parse-rdfxml": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.3.0.tgz",
-      "integrity": "sha512-N8NCjazY+htFRAT7tYuf61fUsNrsp/6CC0mPr8t8w1/ev1FWbIiu4m/JhTEtA4k0eMugX9HUkoN4yhPPa/EIDw==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.4.3.tgz",
+      "integrity": "sha512-BQx8otpEoWCHspnVg0uK6X35vF5R0EDClgZrYsN80xq4IcyibDTj5dPNQdabXKWAIPAmUS7kTqDsGkvlhYPT/g==",
       "requires": {
-        "rdfxml-streaming-parser": "^1.0.0"
+        "rdfxml-streaming-parser": "^1.1.0"
       }
     },
-    "@comunica/actor-rdf-resolve-quad-pattern-federated": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.2.0.tgz",
-      "integrity": "sha512-xtjuvNl/u3qemWGTNvHGe6fcr1XRyu65L4YwlFF0pEMQJR27cE4w1WNiRM1jUp++yFTNbNRHFhEoG+1SW/12kA==",
-      "requires": {
-        "@rdfjs/data-model": "^1.1.0",
-        "asynciterator": "^2.0.0",
-        "asynciterator-promiseproxy": "^2.0.0",
-        "asynciterator-union": "^2.1.0",
-        "lodash.omit": "^4.5.0"
-      }
-    },
-    "@comunica/actor-rdf-resolve-quad-pattern-file": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-file/-/actor-rdf-resolve-quad-pattern-file-1.2.0.tgz",
-      "integrity": "sha512-mX17ZjrH42DTLAwqx8SPuXNzNS9389T/G+prdlWoVhsgCvZhZYNhgFHEvTwP8tpzNWPW//E4M2eEH7X3JuKXIw==",
-      "requires": {
-        "asynciterator": "^2.0.0",
-        "n3": "1.0.0-beta.2",
-        "rdf-string": "^1.1.1"
-      }
-    },
-    "@comunica/actor-rdf-resolve-quad-pattern-qpf": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-qpf/-/actor-rdf-resolve-quad-pattern-qpf-1.2.0.tgz",
-      "integrity": "sha512-zDNoKOrAEuQ1aWFzmHk+GmvQOrfMUcwGXCz4z8nAo6/34/J3MuACzYWT6IRGG+w9bwEc+YZasUc7HW3nZKe9Qw==",
+    "@comunica/actor-rdf-resolve-hypermedia-qpf": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.4.5.tgz",
+      "integrity": "sha512-4+IbNae/KwJC1sTh4hpTGD6FHzL2dGiyC1hmL0lDfJFGr1LjChsn4oJ8hMXXlgmLYJibHWjHyxkPaKV3eqV3Lg==",
       "requires": {
         "@rdfjs/data-model": "^1.1.0",
         "asynciterator-promiseproxy": "^2.0.0",
@@ -1213,24 +1281,58 @@
         "rdf-terms": "^1.2.0"
       }
     },
-    "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.2.1.tgz",
-      "integrity": "sha512-gnEP5pYsvtNNfJ1MlUKcIloomrqGA8zBdPUW6lauF0ZBFFWPmcvZtm900OdQ249QfPAzH5CoqZu9A1rpbMkB0A==",
+    "@comunica/actor-rdf-resolve-quad-pattern-federated": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.4.5.tgz",
+      "integrity": "sha512-azIlzUw86cf/WDpeeQxC2c7MAYUeEGCIzLi+4uuic3tNBh8IsWf8/CYzEIo8kgleNt4gNmpMGroVMD/tkNuriw==",
       "requires": {
-        "@rdfjs/data-model": "^1.1.0",
-        "asynciterator": "^2.0.0",
+        "@rdfjs/data-model": "^1.1.1",
+        "asynciterator": "^2.0.1",
+        "asynciterator-promiseproxy": "^2.0.0",
+        "asynciterator-union": "^2.1.1",
+        "lodash.omit": "^4.5.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-file": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-file/-/actor-rdf-resolve-quad-pattern-file-1.4.5.tgz",
+      "integrity": "sha512-VYJyXL4Oh0TUh9JkIxz0oG6963tcRjH7ZRH26INcuiyqj49qRP12ApD9uCjKQw00gaZdG+PO87dzCoLv7z0kwg==",
+      "requires": {
+        "asynciterator": "^2.0.1",
+        "n3": "^1.0.0",
+        "rdf-string": "^1.3.1"
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.4.6.tgz",
+      "integrity": "sha512-0MUg/bYB74YC+/L20vJPrpOgs9VvHNl0JIg1QKrDN1IfNSsZcRACqYCs5okZDgyRMxTZKU6JWv2UJrLOH6oAZA==",
+      "requires": {
+        "@comunica/utils-datasource": "^1.4.5",
+        "@rdfjs/data-model": "^1.1.1",
+        "asynciterator-promiseproxy": "^2.0.0",
+        "rdf-string": "^1.3.1",
+        "rdf-terms": "^1.4.0"
+      }
+    },
+    "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.4.5.tgz",
+      "integrity": "sha512-PNZGdBOS9yJwTuEypqNb0yEbVxphNgTPupzPGIHbZHt/mVpcOTYyXgDir5glmbtV6bp9Cq+NlLhUJpfMk2Ggcw==",
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "asynciterator": "^2.0.1",
         "asynciterator-promiseproxy": "^2.0.0",
         "node-web-streams": "^0.2.2",
-        "rdf-terms": "^1.1.0",
-        "sparqlalgebrajs": "^1.1.0",
-        "sparqljson-parse": "^1.3.1"
+        "rdf-terms": "^1.4.0",
+        "sparqlalgebrajs": "^1.4.0",
+        "sparqljson-parse": "^1.5.0"
       }
     },
     "@comunica/actor-rdf-serialize-jsonld": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.2.0.tgz",
-      "integrity": "sha512-DbReSq/fofhCg9aoIa5FHAfXOjpPlgZvdj/FzOMa+Cc/8qmxWgMsM64yyAT5zYM8aVkzT8CPTNTnq59/tWUX/g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.4.0.tgz",
+      "integrity": "sha512-6peJZEldsxv1m52iPOb7bVu/4AqCNhu2+Amn7Cq7sJJDBoKwCncPC7fmh8Nvs+mEauO8ohvWriCsYzpZ8aCtgw==",
       "requires": {
         "arrayify-stream": "^1.0.0",
         "jsonld": "^1.0.2",
@@ -1238,272 +1340,342 @@
       }
     },
     "@comunica/actor-rdf-serialize-n3": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.2.0.tgz",
-      "integrity": "sha512-fA7lt8ROSI2+4dA4A2csC033o3ZEIIZyKcxCKZ+LKYNdfYGtggriIrgVoWO+O5Jj2Wyr2YeGtxr3wIyxc+m0pA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.4.3.tgz",
+      "integrity": "sha512-bDJ5B22eaZo5Ny+Uoh+q7AQIev/x/icecesxOYBCnmOEq2qORLmkvJqzyEdfNtP8yUdP3JZnJ4rFoS0JaesO9g==",
       "requires": {
-        "n3": "1.0.0-beta.2",
-        "rdf-string": "^1.1.1"
+        "n3": "^1.0.0",
+        "rdf-string": "^1.3.1"
       }
     },
     "@comunica/actor-rdf-source-identifier-file-content-type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-file-content-type/-/actor-rdf-source-identifier-file-content-type-1.2.0.tgz",
-      "integrity": "sha512-bzfDI6xZ9EM5UgCRg8mK3ut/LH9AbQZCi8stKExvSXYaVQcddFAyqRAIen6pCYFrcff30NnITNZRbpOLM1UKbA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-file-content-type/-/actor-rdf-source-identifier-file-content-type-1.4.0.tgz",
+      "integrity": "sha512-OCMsb2iN6qtHHEXoovO50g1hWNQID9KFGa8a2/dHl74nWb+gDIgS71mEtj23kCJDkak3VQw9Hz2Z0T7221LmkA=="
     },
     "@comunica/actor-rdf-source-identifier-hypermedia-qpf": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-hypermedia-qpf/-/actor-rdf-source-identifier-hypermedia-qpf-1.2.0.tgz",
-      "integrity": "sha512-9IxxvuxkdW5zc/3K3DtULJ38fUKAqTLG4IKGmf3C0YXvti1inoNisOG9zHVr7BoVnwJ4Gku0MESDs5tPdVd1GQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-hypermedia-qpf/-/actor-rdf-source-identifier-hypermedia-qpf-1.4.0.tgz",
+      "integrity": "sha512-0ta8K55Fpmo40pHWZzSnZmboaCQRxMhPTS02TfbUdRft8WZARvO0FqtEX/sKCuJdshJIUh4Ao8l8bIXSM24yWA==",
       "requires": {
         "stream-to-string": "^1.1.0"
       }
     },
     "@comunica/actor-rdf-source-identifier-sparql": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-sparql/-/actor-rdf-source-identifier-sparql-1.2.0.tgz",
-      "integrity": "sha512-2ct+H5ESzWyI79VyZB5BruVcjV7WzK62rl/FhUPJEhnWgSJdUYNiOrrPlXeanmk1ue26ZJhMksqujh8X0bKKCw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-sparql/-/actor-rdf-source-identifier-sparql-1.4.0.tgz",
+      "integrity": "sha512-3KTZrfGsmZI+hGOzzHRohuboKVAXkOGgVO6rgKW2XV9mtTeOrfxD4mGH9A/OD6cdsTJDtVk//UsuUkhEnyc/cg=="
     },
     "@comunica/actor-sparql-parse-algebra": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.2.0.tgz",
-      "integrity": "sha512-8HT1ycEgwD1PuPEM4E1rOmtwfDJrOS1Hk9NFirfOQaY3SlWhUP+9ds7ytDUpyeES4WG2uJuakOSYUR/AV79zXg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.4.5.tgz",
+      "integrity": "sha512-By21ugNeZubzbOGg8087WyiGvM01yoXHzCzUegjWiqw1LNl4Hg5PoIwnHGCmHuWUWT1LGpGVmjS5JgW8AE1GbQ==",
       "requires": {
-        "sparqlalgebrajs": "^1.1.0"
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-sparql-parse-graphql": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.2.1.tgz",
-      "integrity": "sha512-8xBYCNE3Ju+vPMBrTxImqQu1m14zbu3d45TSL2HrgXzv2AFxlXWY7RQ/ukcxkcT0u0GPU10HEQLnQfYz5DY5jQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.4.3.tgz",
+      "integrity": "sha512-ZfVt8ByHGQhEQNqjt2k/S7uzx4+p92fuM41tN7nMQBVNVE8aPtMDeiVD818dK2/pOymUfBma9O4AhmHXr095Mw==",
       "requires": {
-        "graphql-to-sparql": "^1.3.2"
+        "graphql-to-sparql": "^1.4.1"
       }
     },
     "@comunica/actor-sparql-serialize-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.2.0.tgz",
-      "integrity": "sha512-rm5DTbSR6qA3o2Ezcv3cLpaWjnzjzccv7CyNkPayewxTthuogu5bnPekvQ3fXvbhe4bDKdVAO4usUa/mzvkUzA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.4.4.tgz",
+      "integrity": "sha512-LB0nlm/5dSD7XKoUslv4GnW3APWTaJXQvGlwhfTj2cdPZRHj+sq3ZR2ViyuD5LuLmqYIEnnSuaUIcZmX9UByBg==",
       "requires": {
-        "rdf-string": "^1.1.1"
+        "rdf-string": "^1.3.1"
       }
     },
     "@comunica/actor-sparql-serialize-rdf": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.2.0.tgz",
-      "integrity": "sha512-2fC0nlkg2mLSWDsXGxx/nPTjmEsaXchPEwXFrp9/gdlryGZhqmS8NOrGUqzy0TB0QMJrT9zyubT6le04bS+0Mw=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.4.4.tgz",
+      "integrity": "sha512-46/qsi2KS288yQkXLK2ToEe7Z7zWfFQqq5abpctgD9JL7V28i4YF6vlZR2RsqWHAmIgkRLfrJY7JRN3q5P7Xdw=="
     },
     "@comunica/actor-sparql-serialize-simple": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.2.0.tgz",
-      "integrity": "sha512-23yYln0RrtZxME20arih3uyY572phF1OnDPvjEmN1OQUbR99jVdITKLldIRbKcV84y3CySGUXMWTXeEg0qLyVQ=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.4.4.tgz",
+      "integrity": "sha512-osP6Zp0a5Oe8AlJrLOwGcMKHuFb4+3+wjvrUUblorEMY4JRO+taLT/3pNoekoGTZa710SRBOmIqh1lTZvP12eQ=="
     },
     "@comunica/actor-sparql-serialize-sparql-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.2.0.tgz",
-      "integrity": "sha512-jQBJTE87kiIqtr/bbchJVShiNrPRafNKF55G2SFxY9nRVdVsHNWipRanuQ+POWaRF0h2vgiAPb/k4oJyGmzALA=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.4.4.tgz",
+      "integrity": "sha512-XyjqyepaQc5qNN9WyL9pzLxf2wX3hcJBYwuhZEb9UametcMU32Re6EuCXRJLi3RpoEJ1+2GkM6ryzJkVcmn61Q=="
     },
     "@comunica/actor-sparql-serialize-sparql-xml": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.2.0.tgz",
-      "integrity": "sha512-+43F8cBYhyj+THPouEuGjsNtsRYGf87PH6mYylfLbRaZaXGqkWdZFzmbLq8uEzXMTD6Uusb9LTV8vPHsSsQ3+g==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.4.4.tgz",
+      "integrity": "sha512-LSN7aVhlxdNQ675GeTfoOgAYbFtopXX22GLrNznlHSUSI668JGFlqgNsy+3r2vCY9ftEyM4ufMk8F5SsYcc6ow==",
       "requires": {
         "xml": "^1.0.1"
       }
     },
     "@comunica/actor-sparql-serialize-stats": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.2.0.tgz",
-      "integrity": "sha512-jz9UgHMWtWrU+yRj0pN5kTbBzkH02UMDAvVMqpLO+03kpqW+0bYSrCfr7nSm3oKE5sCAUnRFyqtlXaoEF9BwlA=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.4.4.tgz",
+      "integrity": "sha512-37QQ/mimMJTgW5+xSIRBrULitqi4UFQhQ/3mE8qY9P+I2JFgumODPkbZBqPIRb9TsLhqCijir5+SOchxSXMY/g=="
     },
     "@comunica/actor-sparql-serialize-table": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.2.0.tgz",
-      "integrity": "sha512-EYYKU+sq2M+ZaaKzAZzSL8Ze0rQr4Qxx5EnIFwBVeGH95D9hRL7MPqs+ECkHzmndQu52VU5XfqLHJ/R7qvcwkA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.4.4.tgz",
+      "integrity": "sha512-QV+vYd0vKGFo/u727KfqQNBTskk7fH91tfD2JbUlRS7ASGhsKklGp1gm9ucEy7/yJfWh78Ck2dCPvL06fPMc0A==",
       "requires": {
-        "rdf-terms": "^1.1.0"
+        "rdf-terms": "^1.4.0"
       }
     },
     "@comunica/actor-sparql-serialize-tree": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.3.0.tgz",
-      "integrity": "sha512-IUIPEuqj/d5UP4CS+eA1nrtm4zP4lRdLtYeZYdWFr9fQDQ1lijHdO7zzp7JdRmT2EQEL3KM2t98CHZjGKTccbw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.4.4.tgz",
+      "integrity": "sha512-fYLpLliP85L2hai7dE2Z6aJxdEikO4TYGwl9UyZ8P+qmITQ2125TKgRC2tSGR02om+eGwWnt0Yhx+DGwyP0VLQ==",
       "requires": {
-        "sparqljson-to-tree": "^1.2.3"
+        "sparqljson-to-tree": "^1.3.0"
       }
     },
     "@comunica/bus-context-preprocess": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.2.0.tgz",
-      "integrity": "sha512-WqICaslSCMVjwd1z1PvD9EmkhVkotE3415zC+pImkVd+le52sqMaB8Py7E8VAo6Fo9Xmw6yqln1JmFpcKQcVmA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.4.0.tgz",
+      "integrity": "sha512-5fNGyLXhCZSD6xf7V5AUWWGu3Vhj1Ga/TNZu6nCCLhFlxWzQvqnCBOGlAiVrWqLlzMp4HSJbtwLo6FUz6Zkzwg=="
     },
     "@comunica/bus-http": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.2.0.tgz",
-      "integrity": "sha512-iDDbSxLWB1ZG3BZPxdv541zF+0Qd3cGbypVyiAqFSmBu72a9sQxgONXj4IpcSyev8o7ox4biC/ca+52wIGMbtA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.4.0.tgz",
+      "integrity": "sha512-paeLBt/4ArNvj/348cuUm1VYG494WcQhiXTTD69GD6ienxizAbisYSWhmSDNOPtS/atLBcifx8uoyREOLrs0sw=="
     },
     "@comunica/bus-init": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.2.0.tgz",
-      "integrity": "sha512-J8D1sRbtEFjk0cuzWI5/t4UuKA4OzBiMVjURD2zDbc6HZJ9DQJkzFnbFmxqfX2/pv4n1SR4QWgW/XWz3sO5ing=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.4.0.tgz",
+      "integrity": "sha512-NPjWh6x5w+EqMVC7Wy5hj2pRLEsRuxy+9IThBRrQhJCnrWxA6+iz06N+7Kcyfp5796ueCM60i5j4DgcCIQDk5Q=="
+    },
+    "@comunica/bus-optimize-query-operation": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.5.0.tgz",
+      "integrity": "sha512-+75LI5G8Qu0PkxwwTWaMYlFJFbitMybSi8DOxezg0P+mGgO9tejcYUTsQeG+8Po3HhzAn3c/XXOxkOb70dqMgA==",
+      "requires": {
+        "sparqlalgebrajs": "^1.4.0"
+      }
     },
     "@comunica/bus-query-operation": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.2.0.tgz",
-      "integrity": "sha512-j+xV1jdXJc+QLhSxo/U+Y9IwXdRkm1xrjVbRXQHujAxFhcD+OFSNIKoateYrupyNiEPhCeM+5GXrGJ6pvhunHw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.4.4.tgz",
+      "integrity": "sha512-0i4Q3c/RPLDbjvXqstQjaQhjSPGTqahpNNR0mGYbzQLkmtP0n7eH5IaBRxesCBWQZ3QyibbF0t1pqNGziZkrRg==",
       "requires": {
-        "asynciterator": "^2.0.0",
+        "asynciterator": "^2.0.1",
         "immutable": "^3.8.2"
       }
     },
     "@comunica/bus-rdf-dereference": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.2.0.tgz",
-      "integrity": "sha512-rodFtHiC61h4YYBQiYK9DxaUVWruVAgXJUZKM9DybjJ4noTWY/yDiVhhFv1/x6Sp15MsfVZbbZZW0yMpYer70g=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.4.0.tgz",
+      "integrity": "sha512-JnpiqJNuENjmDW3PWM86un/rzAJrHHXZfyrsz6gUnOR7UJolGgZgEm9vLfRBYrz4sF7ezrtl0UPF+VvJ7xdBeg=="
     },
     "@comunica/bus-rdf-dereference-paged": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.2.0.tgz",
-      "integrity": "sha512-NhGxjxA6zvPxiUsOG6qf9H/j+Y8V39sO1CY8ZhaR2r1zNas+Iti4l4VwJ5GiH8dSLZ5/yy5HqTtjsOhDsJGOdA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.4.0.tgz",
+      "integrity": "sha512-tsDujGS8bKCyJBG96hSOyYaePx5x5IIdDRGCQHgSEoUDgwe0QaksSF5g2S1odJhqyLZ8F/YDhf4qIwZ/CJWWog=="
     },
     "@comunica/bus-rdf-join": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.2.0.tgz",
-      "integrity": "sha512-8yaYY+K3Q/hM4VdWECtft5NZtGiF0BLPCpzSDSCg87SSUqFhjrWWlvPth0x0iRO+OJxz/JqcxOPdnjCp+idqFA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.4.4.tgz",
+      "integrity": "sha512-Kuv2C9hKvo/blq9VxAdKWSjUGsdKP8Z4G/T2LxlbT5fmF531QQjHnrE4KtH/xUnMnzhUNfv1jvOqcCyzoDeiPw==",
       "requires": {
         "lodash.intersection": "^4.4.0",
         "lodash.union": "^4.6.0"
       }
     },
     "@comunica/bus-rdf-metadata": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.2.0.tgz",
-      "integrity": "sha512-is5vOEwlTi/76OEaWa3ATvBE+zISJNGOcPItD8VaNxtE36NKy1KZR96f7StACUxiHEZcyxIgF8RIIZQlpt67aw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.4.0.tgz",
+      "integrity": "sha512-kbfS/H7QUIpvJyJWUnT5dgMZLIbNlCICeybnRoSbNW2kLKlrwWww/pYKigkgn22J4t32Wf+WYuIjX8X/K5sG8Q=="
     },
     "@comunica/bus-rdf-metadata-extract": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.2.0.tgz",
-      "integrity": "sha512-kG3waFHLv9avfL5NNq9MjsROCFRgtXCuimbZ8+6DR/k8yuoz83ZBM+zfWzZ6snhu/Hy/b3/n/XD/stVH3AnVjg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.4.0.tgz",
+      "integrity": "sha512-dzXE6LTwpSFlBFtagHRX7+xLs6DoaDi74BTw5YCH3tjfWJUirRNFPXq1L3mwoEifuBSrsMKK6uQKw7fn5YB+0A=="
     },
     "@comunica/bus-rdf-parse": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.2.0.tgz",
-      "integrity": "sha512-VCqMm4DzCrWTxR0SRXqOJnnyItbaZKlH/evGCvd4zJRN8RoBJHUU6/fFx6MJNgvm4FpgRAwXcTgwJZeJvC8aew==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.4.2.tgz",
+      "integrity": "sha512-xR7l4rH8nlXd5LdHrUsQ3UNTJlxOnZQLwrhC6ge9RTdwCKRkeQpzdRjTklSml/IZeIdiw6iFY5uT3bY/6j4TvA==",
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.2.0"
+        "@comunica/actor-abstract-mediatyped": "^1.4.0"
       }
     },
-    "@comunica/bus-rdf-resolve-quad-pattern": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.2.0.tgz",
-      "integrity": "sha512-3l7pAtpZVUUQg9oXaFaxwCSld6+qdoz16yxz9GuVG6u2wsOqlG3GHz6FBqduEIOPCswNGG/y2vEzD4LFTZn3JQ==",
+    "@comunica/bus-rdf-resolve-hypermedia": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.4.5.tgz",
+      "integrity": "sha512-OEi0JSAkM+r0Eo6iV5e4gQcT+ARhf/TxWP6Q5/jL24ByXp/hs7ixQ7//o24+LNjUwytgUaIDF8uKriGUEdGTKA==",
       "requires": {
         "asynciterator": "^2.0.0",
         "asyncreiterable": "^1.1.0"
       }
     },
-    "@comunica/bus-rdf-serialize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.2.0.tgz",
-      "integrity": "sha512-6C8kHCQs1bHwS4CuSCvMQh6J0AFvkHhAET5HtAGxJumswLWKRPP1Rl99+zhXMlmTOe1Bq2hjqeDUni/Bz+z8wA==",
+    "@comunica/bus-rdf-resolve-quad-pattern": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.4.5.tgz",
+      "integrity": "sha512-dvlOL52M4GVFUOIXAPPmJozq3ejp97Z4Fh3NYBZpW8OBfeF2wbTlHFbNXisdgd/7nfZUQdb7yyHhrrd4UU1GCg==",
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.2.0"
+        "asynciterator": "^2.0.1",
+        "asyncreiterable": "^1.1.0"
+      }
+    },
+    "@comunica/bus-rdf-serialize": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.4.0.tgz",
+      "integrity": "sha512-eEkdnh5clCI+AC8aFdRTOASUCGf0o1RryqRZfOT6hHWGGAUeTt+K1c3QSaltBPsubqj3v6NBMWrCj1/7Nhozfg==",
+      "requires": {
+        "@comunica/actor-abstract-mediatyped": "^1.4.0"
       }
     },
     "@comunica/bus-rdf-source-identifier": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-source-identifier/-/bus-rdf-source-identifier-1.2.0.tgz",
-      "integrity": "sha512-6Ix4OhjA01ZAeEN1fzvTirsitpyk32i7+SabE/K+CCE0vg/f4+3ok038409LCKPmDo+njm6g+x4JMVM5YEitPA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-source-identifier/-/bus-rdf-source-identifier-1.4.0.tgz",
+      "integrity": "sha512-BNBlCPX55G3F1Bd1+U536t7apEKCMpGcw+fgxKHvNXxrO5FdmkGr4933eVEeAJ5eR1PO5T7mEFMmTkmLAFRpuQ=="
     },
     "@comunica/bus-sparql-parse": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.2.0.tgz",
-      "integrity": "sha512-S0D/jjQbTfEnY2AVAmO9qDsQz4TENQfoga4apij/SdgRjb11rFecE4SBK1+rBUVoT4Y/bD7LG6PY6JzdzaF97g=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.4.0.tgz",
+      "integrity": "sha512-IzyTYlf6FkkpTsvQWzu8e8WDGVgjfI90V8YWH+DEgn1PZsSIdD9u9wQBlIoWeZTA3w2CqbNwTnLtuDErxew6hA=="
     },
     "@comunica/bus-sparql-serialize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.2.0.tgz",
-      "integrity": "sha512-U16IhM+YaOP/xiPXmArvHNJn4lQ8kBXZC7PSbRePtzbJ2jI8X0fa0ti7e0Ahcs5CBs1xTWIkrHslr7FRsj170A==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.4.4.tgz",
+      "integrity": "sha512-cTokRdeLl6nNF3k4/PkzBrKVGoWjd8YnRyYH78SBehzkOHK2OlP4FG8s90A5SFksUQIVHM5xVPZ90Hmt6V35dA==",
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.2.0"
+        "@comunica/actor-abstract-mediatyped": "^1.4.0"
       }
     },
     "@comunica/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-qmNCN9YsG00J+rsD6wI95F9A8QKnCl5AyusL4bgw3P09PwOUSdCYcHPHYYUKBoc7bf9k6aqb7lMBRWqfM/rasA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-1.4.0.tgz",
+      "integrity": "sha512-P5lyRHiHbNkpUYsL4q/FOYZiTE+f01Yikz2bJ8UCw8Nch+Y5C93ujOz2/iMmXY8ywn83q8bcLSvDtY1LLfzCIw==",
       "requires": {
         "immutable": "^3.8.2",
         "lodash.assign": "^4.2.0"
       }
     },
     "@comunica/logger-pretty": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.2.0.tgz",
-      "integrity": "sha512-OFI8A+HUi/xKvCzdnSYlVlDDhoyAr2/gx/Hf+us/brSKromO5czgJH+nZqolD8AhiheEk9HFBbBDTxIS8lwNPg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.4.0.tgz",
+      "integrity": "sha512-8y7clI4JlaBMaD6WZGmLAhm4ms+Bq5mBnxzAXE6zjcU5yYAlRbBtxn9TbxJ1TqmYqPaS3tfI3m5VOX5fwOz0TQ=="
     },
     "@comunica/logger-void": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.2.0.tgz",
-      "integrity": "sha512-TRt5Z157zmVBVYU5LKBj/Bu8dGF8pNwMga8gOdULbPLCQX3wjIbT86EDhxpZa18SRovIoWeB9OlyzChBz3XokQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.4.0.tgz",
+      "integrity": "sha512-D1KWm0oKVIlUNBuwkQt4FOUUMoc6E8Qgd742hDI3GXDxW/sxgn59tPoqg1gdc5fE2/dJ0vPa1tnu+js+kYwQEQ=="
     },
     "@comunica/mediator-combine-pipeline": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.2.0.tgz",
-      "integrity": "sha512-SxVPj5/QvTQxiBdW969hW73QAnsf3GRZliE7C2A2TKMiyb4zxCmQAYCc1moEa7LvSMq/MoeD+u4/NCQt0Cy7+g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-1.4.0.tgz",
+      "integrity": "sha512-JScniGlCDFE05QhZ0IuY14W3qe6B0P1ucrbLzM/FsJVuWAfqADvA8MP8kB8BCIjunwnLXwxXhiOacSt6aIv9Vg==",
       "requires": {
         "lodash.map": "^4.6.0"
       }
     },
     "@comunica/mediator-combine-union": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.2.0.tgz",
-      "integrity": "sha512-LlHhtxeJBITVL+9pFrTjBkHYUYJn28HIruTuebn85Yxc0m6OgDfQPpJ++UR4oPIFIbrvHnnCK8nwZAfOY5SdNw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-1.4.0.tgz",
+      "integrity": "sha512-kQKV/a7zjJ8chDCUo7e+1zn0EHb2udwKvK7iIJ2umSPg53wRs2BTj8JU0e464ZEz0uPI1VsDhCvCa/MCGMyH3w==",
       "requires": {
         "lodash.defaults": "^4.2.0",
         "lodash.map": "^4.6.0"
       }
     },
     "@comunica/mediator-number": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.2.0.tgz",
-      "integrity": "sha512-odYfhmNTPbSGKVd1VJA62OBySwuNgZb6l9PNUeOrLLq224r0JvwzpIJMxDoO/bg5l4LVcNIv/taO3B4SwejF8g==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-1.4.1.tgz",
+      "integrity": "sha512-w1SbVhs/HTqBwYQnatk3JsgriUYtRptaxz3DJOTX1R01Kfje+lWdPkRxm+AhbO35hD3Q3SfUkTOLoOsiVVIjKQ==",
       "requires": {
         "lodash.map": "^4.6.0"
       }
     },
     "@comunica/mediator-race": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.2.0.tgz",
-      "integrity": "sha512-ms9klWN9Bq4aR86SXKtMnyjPtrBT7OcDsWXnfSK7iuVAJA8Fuko4AjeE/ogYdlYmtYWP6b4bx6MN/VnlSk9bMw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.4.0.tgz",
+      "integrity": "sha512-C6ZuPNXJnwPqz61fk1c4dwvXZANkqN2sPC0ifgUMhlJWr/QvJkE8aI6/1EVZFHx5BQ5zOn54kYEum/DgJMCtkA=="
     },
     "@comunica/runner": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.2.0.tgz",
-      "integrity": "sha512-5cJmrnCGJEWFtIOfiQwA3j0J93wG7oXdkUU34sxwY0bQg4i1X7hWpOKhYB13hdt9ZrzH1g1alb7XiRGG0pPREA==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.4.4.tgz",
+      "integrity": "sha512-m2ccZome8l1v39gIi1r56bzNRkQaFPrmXI+v+VxsPy5761wSem4eQPD2f1FOGmm2rmLoA1L3unEeSm9pHYQvrA==",
       "requires": {
-        "componentsjs": "^3.1.0",
+        "componentsjs": "^3.2.0",
         "lodash.assign": "^4.2.0",
         "lodash.defaults": "^4.2.0"
       }
     },
     "@comunica/runner-cli": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.2.0.tgz",
-      "integrity": "sha512-sYjPQUbwKDNC1yrL1KxDTyI6HzwYCbYrUtO5QgxO2PqrcYKVI/jOiGrqWoxjpLZSOXpsSJCBhsf+RfZVVvkeUw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.4.4.tgz",
+      "integrity": "sha512-Dg7nl+1C1mMGnZADDxzoadsFEhaeAkG2JNGfYk0qMMKkpuXAEGL9rnznv/qLt+jarM1AD1xxKRnlEtnOwxy0Zw==",
       "requires": {
-        "@comunica/runner": "^1.2.0"
+        "@comunica/runner": "^1.4.4"
+      }
+    },
+    "@comunica/utils-datasource": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.4.5.tgz",
+      "integrity": "sha512-0I5LhzL/xKzENrmO6zbVQSodo4h7k2wu9CCQ8peDCj3hjViZeeb1oORYQXma+Ih/uLh/aYUuUe0tl9HfMQHWBA==",
+      "requires": {
+        "arrayify-stream": "^1.0.0",
+        "asynciterator": "^2.0.0",
+        "asyncreiterable": "^1.0.0"
       }
     },
     "@rdfjs/data-model": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.1.0.tgz",
-      "integrity": "sha512-vK7TlSFBJQihqMoMgXK/VtcRV+rCQSOLB9VGAfv4Pr6BzUbBcR0CeM/RpkD4bHGX3816eaaURH1CNgN7togWdw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.1.1.tgz",
+      "integrity": "sha512-4jb1zc77f27u/MLVhpE/zHR1uvdH4XElXG63rJP/kVnvKoHtVfyJSEqN9oRLANgqHJ9SNwKj9FXeNFZ4+GGfiw==",
+      "requires": {
+        "@types/rdf-js": "^2.0.1"
+      }
+    },
+    "@types/asynciterator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/asynciterator/-/asynciterator-1.1.1.tgz",
+      "integrity": "sha512-KgjXxTtWbMW7UA4oZauIfg2rCl5+5LbsoVF5DwwpXVQxzSbez2PQ9NAlbJlBjIHqKLOpWcdjqL+wyrNepvTZOg==",
+      "requires": {
+        "@types/events": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/events": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+    },
+    "@types/lodash": {
+      "version": "4.14.119",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.119.tgz",
+      "integrity": "sha512-Z3TNyBL8Vd/M9D9Ms2S3LmFq2sSMzahodD6rCS9V2N44HUMINb75jNkSuwAx7eo2ufqTdfOdtGQpNbieUjPQmw=="
+    },
+    "@types/lodash.isequal": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.3.tgz",
+      "integrity": "sha512-tpTUmHksO2H9RF98Y2w7v06ZeEKAxHPo2ysL0bV5qv5UBweiZl33NFu5QYmYOSxSnHMqBt/vsVsBVeQAcJiokg==",
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/node": {
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+    },
+    "@types/rdf-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.1.tgz",
+      "integrity": "sha512-x3Qct8TPilUos4znM1gANmtTvjOFdDRItmpEM2Nu9QgAx258FN9k22OvOu2TmPzOlx8a1FLdEW3o33UXHQt5ow==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "JSONStream": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.4.tgz",
-      "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "requires": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -1749,12 +1921,9 @@
       "dev": true
     },
     "asynciterator": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-2.0.0.tgz",
-      "integrity": "sha512-sAD0fwT3h5hC8O/tclYGLWy3xPs8G8P20ROAOzDKG7SBkdySRAo/NMftlE37cVRe+RAfzGT5dYG+malp2KfefA==",
-      "requires": {
-        "immediate": "^3.2.3"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-2.0.1.tgz",
+      "integrity": "sha512-aVLheZsDNU5qpOv6jZEHnFv79GfEi+N0w/OLmMmXZfGD8XFFmPsRhkSqleNl9jS6mqy/DNoV7tXGcI0S3cUvHQ=="
     },
     "asynciterator-promiseproxy": {
       "version": "2.0.0",
@@ -1765,9 +1934,9 @@
       }
     },
     "asynciterator-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/asynciterator-union/-/asynciterator-union-2.1.0.tgz",
-      "integrity": "sha512-RxNma8VgmdB/w0iKe1+2md4iXAi8pQgmVd/u7VE/DuOqiSeDDZKCy7J7nG4JG/soxdeWQYyQXmhMvB/ZE4djTw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/asynciterator-union/-/asynciterator-union-2.1.1.tgz",
+      "integrity": "sha512-GdBwEaTebKLHlHv6MgseEzmKmfpARlw53YV7tijxEkgsB7azlUpZoXg8FDRfCb1FkoHA2cN77mPPro26lKABCA==",
       "requires": {
         "asynciterator": "^2.0.0"
       }
@@ -2181,9 +2350,10 @@
       "optional": true
     },
     "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
+      "optional": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2500,9 +2670,9 @@
       "dev": true
     },
     "componentsjs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-3.1.0.tgz",
-      "integrity": "sha512-xL7v5rs3uoBRLaR//mzsB5V54EwFhWMXhsfMXE1DUsRrVgqPwyIJLd8B6f6w84/y5qJQK15znauILIy+vIuVlQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-3.2.0.tgz",
+      "integrity": "sha512-ruO5GneIIYtmi+Bg0Yj1Wqe+QBAeUGVjjn+u/TBNfqYZBoCnbHZV/gq8vm9bw6vWp5QBSjywy0PNNmgV71dxmA==",
       "requires": {
         "global-modules": "^1.0.0",
         "jsonld": "^0.4.11",
@@ -2873,7 +3043,7 @@
     },
     "es6-promise": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
       "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
     },
     "escape-string-regexp": {
@@ -3349,19 +3519,19 @@
       }
     },
     "fetch-sparql-endpoint": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-1.3.3.tgz",
-      "integrity": "sha512-MaV0itY6lBYnq4JxZ218mSzuazQymUEKITpO7tZuIyVfXPvKXs2w72Oi1E962F9A7pEdYnAOD/alCU2XepiOfg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-1.4.0.tgz",
+      "integrity": "sha512-RBu3fmK8fpExr5JpJfr3/NpOYcelhWtmEogADjwRWcT8T6CiMb1vpz7y3GDmuBUXShM5xzOyYy6qsyDsCsADFg==",
       "requires": {
         "is-stream": "^1.1.0",
         "isomorphic-fetch": "^2.2.1",
         "minimist": "^1.2.0",
-        "n3": "^1.0.0-beta.1",
+        "n3": "^1.0.0",
         "node-web-streams": "^0.2.2",
-        "rdf-string": "^1.2.0",
+        "rdf-string": "^1.3.1",
         "sparqljs": "^2.0.3",
-        "sparqljson-parse": "^1.3.1",
-        "sparqlxml-parse": "^1.1.2",
+        "sparqljson-parse": "^1.5.0",
+        "sparqlxml-parse": "^1.2.0",
         "stream-to-string": "^1.1.0"
       }
     },
@@ -3445,9 +3615,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
-      "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
+      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
       "requires": {
         "debug": "=3.1.0"
       }
@@ -3833,14 +4003,15 @@
       }
     },
     "graphql-to-sparql": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-1.3.2.tgz",
-      "integrity": "sha512-0nfFz/Vjkvqd/t6YSsFT28kJwH/cRVWf6yHTXAvDqqeCUzPA9uSaNvw1Tw1SmZQMjU/Plp8zPjOhP8DnW2PmZg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-1.4.1.tgz",
+      "integrity": "sha512-Jk4gfE1BbqQiOsEhgwufinlC4WefJb29JzcX7QoTxxgw8/ddz0N7IvMd2V56oNuKyZUj8sDKAhgUNjUVEpc/VA==",
       "requires": {
-        "@rdfjs/data-model": "^1.1.0",
+        "@rdfjs/data-model": "^1.1.1",
+        "@types/rdf-js": "^2.0.1",
         "graphql": "^14.0.0",
         "minimist": "^1.2.0",
-        "sparqlalgebrajs": "^1.0.1"
+        "sparqlalgebrajs": "^1.3.1"
       }
     },
     "growly": {
@@ -4151,11 +4322,6 @@
       "requires": {
         "minimatch": "^3.0.4"
       }
-    },
-    "immediate": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
     },
     "immutable": {
       "version": "3.8.2",
@@ -5745,14 +5911,21 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonld": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.1.0.tgz",
-      "integrity": "sha512-tx87xNtu2hGabr7mhSyXTI8q+Fz3pl+50B/JislFPwAz8ud0KTTQpNjU74tJIegFAHve9UFYzzj4YVTIrac0Hw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.4.0.tgz",
+      "integrity": "sha512-42FBpURzGMJc1rjpo9JU32EJ3Uf4k1HyRgvj1Np4dpEcrkdui0sMNHgKDE88It0iMhVzyK/cipcJ3Co2Nx5CLA==",
       "requires": {
-        "rdf-canonize": "^0.2.1",
-        "request": "^2.83.0",
-        "semver": "^5.5.0",
+        "rdf-canonize": "^0.3.0",
+        "request": "^2.88.0",
+        "semver": "^5.6.0",
         "xmldom": "0.1.19"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+        }
       }
     },
     "jsonparse": {
@@ -5933,6 +6106,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -6124,14 +6298,16 @@
       "dev": true
     },
     "n3": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.0.0-beta.2.tgz",
-      "integrity": "sha512-dY0Q21JhNJozPMSijKI9phfgocXb7hF9F8zOPnsRu0Dy61eQwQVKcFEw59V0sn2F/neJjNg7WHmNtGLMkPpKPA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.0.3.tgz",
+      "integrity": "sha512-IdcCNqb/1gj9fX63hoVEn3/Z1u9iLJiYLSpesmqT3+5UrxcYG5YldUP6T2okNRZKzyVdqz+I0PExGkWkz9gcZw=="
     },
     "nan": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
+      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -6802,7 +6978,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "psl": {
       "version": "1.1.29",
@@ -6850,39 +7027,71 @@
       }
     },
     "rdf-canonize": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-0.2.4.tgz",
-      "integrity": "sha512-xwAEHJt8FTe4hP9CjFgwQPFdszu4iwEintk31+9eh0rljC28vm9EhoaIlC1rQx5LaCB5oHom4+yoei4+DTdRjQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-0.3.0.tgz",
+      "integrity": "sha512-LHyT23nTPy9ASARyoYg/zvNNysJ3cfUAFpPJBbGIjhoENHiUK+l/T3z7oAttqNMBvrJRJuEvcuhyT+YsnC73Dg==",
+      "requires": {
+        "node-forge": "^0.7.6",
+        "rdf-canonize-native": "^0.3.0",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+        }
+      }
+    },
+    "rdf-canonize-native": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize-native/-/rdf-canonize-native-0.3.0.tgz",
+      "integrity": "sha512-t/EI0B0GSV+eM2d/Nnxvo5PHomO5Qc5EzBxxtxcrzd8Hx9wHGbh6VFCn4A5/RehQATeoAfynifszJZO+bDO8Ow==",
+      "optional": true,
       "requires": {
         "bindings": "^1.3.0",
-        "nan": "^2.10.0",
-        "node-forge": "^0.7.1",
-        "semver": "^5.4.1"
+        "nan": "^2.11.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+          "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+          "optional": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "optional": true
+        }
       }
     },
     "rdf-string": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.2.0.tgz",
-      "integrity": "sha512-Dhua1a0xIv4e2G41zGmAVC5C7smSqgR0XDt8Tj7gQqwjWiBWhu53N9wMeaUmP4O/2nIFLvPzEhUNYk0aNjl1pQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.3.1.tgz",
+      "integrity": "sha512-Pcw6aZRfto2cZodK5kSqFZW8mz6nfKLxSfjOSrTi5ajb2CSIwzqGx7UniysgKoV2i7tQL5dpPgCgY80upCiRUw==",
       "requires": {
-        "@rdfjs/data-model": "^1.1.0"
+        "@rdfjs/data-model": "^1.1.1"
       }
     },
     "rdf-terms": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.3.0.tgz",
-      "integrity": "sha512-bkvVLdUtafwlBxxbt+WNIlYg4DmkJXSeX818Z2WJWyWL9UxKsHoNJqef3Z+gkB4kkQFM4ggi6aO0vXe3An7jGw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.4.0.tgz",
+      "integrity": "sha512-xvi9ckIpZraUWs6MfTrjan3OCy5ec7cl12Hrhw1Q7t4NTMyKpiNbC0IqeisDiVCPHrX0e/AbSIibBnIA5VDpyw==",
       "requires": {
-        "@rdfjs/data-model": "^1.1.0",
+        "@rdfjs/data-model": "^1.1.1",
         "lodash.uniqwith": "^4.5.0"
       }
     },
     "rdfxml-streaming-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.0.0.tgz",
-      "integrity": "sha512-TGcp+Ltx+nbd7kOGhffmcOPH5Ux9W8OE0J61I+l5iyK+1YGxROReyESEA6FtHuOjBmA/f4JeL0ksiGSfjiDw9Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.1.0.tgz",
+      "integrity": "sha512-0cMdocZQoqx6052vnFAh9fo0bVcRJbav6UVRCeAJiNQoRjNhvY/QwwIPPrk60h+oN7gUKJLk6adFQRBTjJJLqQ==",
       "requires": {
-        "@rdfjs/data-model": "^1.1.0",
+        "@rdfjs/data-model": "^1.1.1",
+        "relative-to-absolute-iri": "^1.0.0",
         "sax": "^1.2.4"
       }
     },
@@ -7055,6 +7264,11 @@
           "dev": true
         }
       }
+    },
+    "relative-to-absolute-iri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.1.tgz",
+      "integrity": "sha512-EOPIZfD9RGVPJPSlNtWLlURO6Cq4NnTtd/AXmc1FbKjlrNNP8LZrYBaSIn4eH6+InQSbTNCz0YWb5F7N5YCryQ=="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -7305,9 +7519,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "sax-stream": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/sax-stream/-/sax-stream-1.2.3.tgz",
-      "integrity": "sha1-X2sI8mpaG7ivqGwXI1Rf02gxvq4=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax-stream/-/sax-stream-1.3.0.tgz",
+      "integrity": "sha512-tcfsAAICAkyNNe4uiKtKmLKxx3C7qPAej13UUoN+7OLYq/P5kHGahZtJhhMVM3fIMndA6TlYHWFlFEzFkv1VGg==",
       "requires": {
         "debug": "~2",
         "sax": "~1"
@@ -7326,7 +7540,8 @@
     "semver": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+      "dev": true
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -7562,45 +7777,61 @@
       "dev": true
     },
     "sparqlalgebrajs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-1.1.0.tgz",
-      "integrity": "sha512-5rPL85zA7WzxJhrmJXobYcQZFv+dB++BOq1oqi9DaP/U4Scw3/3Vr8HYV8R/BKrxeBwAVxBFAjP80HXjmGcl6w==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-1.4.2.tgz",
+      "integrity": "sha512-gkLgH4T1exMRl0MAvCBePnkOx2WVj8lYwME1mxNEcgC2TPHuOMuImDJgnM2RJ+nZfbQ1CRsEe8y9UQJz06QLnw==",
       "requires": {
-        "@rdfjs/data-model": "^1.1.0",
+        "@rdfjs/data-model": "^1.1.1",
         "lodash.isequal": "^4.5.0",
         "minimist": "^1.2.0",
-        "rdf-string": "^1.2.0",
-        "sparqljs": "^2.0.3"
+        "rdf-string": "^1.3.1",
+        "sparqljs": "^2.2.1"
+      }
+    },
+    "sparqlee": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-0.0.1.tgz",
+      "integrity": "sha512-k7PIJyC2gal0QQ5ia1ZmyeFNAth9s6/A3hZKP7PDPqYB5OgbrTT5Z/uEu5cIS0l+GqiHgR39sdm3XAzD94bfsQ==",
+      "requires": {
+        "@rdfjs/data-model": "^1.1.0",
+        "@types/asynciterator": "^1.1.0",
+        "@types/lodash": "^4.14.105",
+        "@types/lodash.isequal": "^4.5.2",
+        "@types/node": "^10.11.4",
+        "@types/rdf-js": "^2.0.1",
+        "immutable": "^3.8.2",
+        "rdf-string": "^1.1.1",
+        "sparqlalgebrajs": "^1.1.0"
       }
     },
     "sparqljs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-2.1.0.tgz",
-      "integrity": "sha512-WXb2utLh6A9tbpkz4I23grNuv42fh2ttxGONLz1mz5TvZtJEelody0jEpC7U84cZZn+sNqOQSTdv+kcESHlGqw=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-2.2.1.tgz",
+      "integrity": "sha512-nvwCxdqZbggDEFc/1b4FfAUxAzBjAkpruDRwqQSMApyvr94qxta6DG9hCFI423i/1wJkPi5pggLmN0q2YdgpCg=="
     },
     "sparqljson-parse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-1.3.1.tgz",
-      "integrity": "sha512-XOgbNTIR3xFAKSKGcHfHTQP/VTO6TVK53pY6E9kAJEZaHv3ADulvcg4oBjztGYeWC6vF3HasBLsvcwWzxr0krg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-1.5.0.tgz",
+      "integrity": "sha512-9avQc1mfxhbNnLis4nW92CVeoX3vh7csIZw4WS7Zwlpgk++GHMeWIkGWc15mlFUoe97LosNkjGcJxEEkO7DHaw==",
       "requires": {
-        "@rdfjs/data-model": "^1.1.0",
+        "@rdfjs/data-model": "^1.1.1",
         "JSONStream": "^1.3.3"
       }
     },
     "sparqljson-to-tree": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-1.2.3.tgz",
-      "integrity": "sha512-QFt87/raXcRUNpaAFIbvk+Uxlg1g0JfhZJLBekBz8z31borMUDpiAO/AVklLlmrcOVNXLBMxzU2k5Ot/8lxkuA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-1.3.0.tgz",
+      "integrity": "sha512-1GmNXEiC452rwMmmkhJ0Ppk0KKumgyBdtXmCFP/hVoJ1MqKEzMu50gjsxbwMau3FQGAOEbwwj0EtkUy82F2Qyw==",
       "requires": {
-        "sparqljson-parse": "^1.3.1"
+        "sparqljson-parse": "^1.5.0"
       }
     },
     "sparqlxml-parse": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-1.1.2.tgz",
-      "integrity": "sha512-4BnBQQiBMg0NQXRDVi16tfTef6jv5JXBkbRXBv/OVOsq2yUrbklMDnKmsrledbgtDUpHEblehr/yy5uMHMuFgQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-1.2.0.tgz",
+      "integrity": "sha512-yRDYaRH5Fv6fHywWu8lG+WK2NLeg+p15DTjD5qkNq7njxJseKh2Eq1E1L9XvUEcwhR6aK5L8h07AO4lYA0BFFQ==",
       "requires": {
-        "@rdfjs/data-model": "^1.1.0",
+        "@rdfjs/data-model": "^1.1.1",
         "sax-stream": "^1.2.3"
       }
     },
@@ -8565,7 +8796,8 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yargs": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lib"
   ],
   "dependencies": {
-    "@comunica/actor-init-sparql": "^1.3.0"
+    "@comunica/actor-init-sparql": "^1.5.0"
   },
   "peerDependencies": {
     "ldflex": "^1.0.0"

--- a/src/ComunicaEngine.js
+++ b/src/ComunicaEngine.js
@@ -12,8 +12,8 @@ export default class ComunicaEngine {
     this._engine = newEngine();
   }
 
-  get _document() {
-    return (async () => (await this._subject).replace(/#.*/, ''))();
+  getDocument(subject) {
+    return subject.replace(/#.*/, '');
   }
 
   /**
@@ -31,7 +31,7 @@ export default class ComunicaEngine {
     const next = async () => {
       if (!bindings) {
         // Determine the document to query from the subject
-        const document = await this._document;
+        const document = this.getDocument(await this._subject);
         const sources = [{ type: 'file', value: document }];
 
         // Execute the query and retrieve the bindings

--- a/src/ComunicaEngine.js
+++ b/src/ComunicaEngine.js
@@ -12,17 +12,26 @@ export default class ComunicaEngine {
     this._engine = newEngine();
   }
 
+  get _document() {
+    return (async () => (await this._subject).replace(/#.*/, ''))();
+  }
+
   /**
    * Creates an asynchronous iterable
    * of results for the given SPARQL query.
    */
   execute(sparql) {
+    // Comunica does not support SPARQL UPDATE queries yet,
+    // so we temporarily throw an error for them.
+    if (sparql.startsWith('INSERT') || sparql.startsWith('DELETE'))
+      return this.executeUpdate(sparql);
+
     // Create an iterator function that reads the next binding
     let bindings;
     const next = async () => {
       if (!bindings) {
         // Determine the document to query from the subject
-        const document = (await this._subject).replace(/#.*/, '');
+        const document = await this._document;
         const sources = [{ type: 'file', value: document }];
 
         // Execute the query and retrieve the bindings
@@ -52,5 +61,12 @@ export default class ComunicaEngine {
         bindings.on('end', done);
       }
     }
+  }
+
+  /**
+   * Throws an error for update queries.
+   */
+  executeUpdate(sparql) {
+    throw new Error(`Comunica does not support SPARQL UPDATE queries, received: ${sparql}`);
   }
 }


### PR DESCRIPTION
This adds an overridable `executeUpdate` method in `ComunicaEngine` for SPARQL UPDATE queries that throws an error by default.

This is so that `@solid/query-ldflex` can override this.