### PR TITLE
Support multiple sources of any kind

### DIFF
--- a/config/config-default.json
+++ b/config/config-default.json
@@ -12,6 +12,8 @@
     "files-cais:config/sets/rdf-dereference.json",
     "files-cais:config/sets/rdf-parsers.json",
     "files-cais:config/sets/context-preprocess-rdf-source-identifiers.json",
+    "files-cais:config/sets/rdf-source-identifiers.json",
+    "files-cais:config/sets/resolve-federated.json",
     "files-cais:config/sets/resolve-file.json",
     "files-lc:config/sets/resolve-rdfjssource.json",
     "files-cais:config/sets/resolve-sparql.json",


### PR DESCRIPTION
This requires no change in query-ldflex to work, but would then support queries such as `data.from([document, tpf, rdfjssource])[subject]`.

This solves solid/query-ldflex#13 and solid/query-ldflex#15.