### PR TITLE
Update Comunica to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -773,22 +773,22 @@
       }
     },
     "@comunica/actor-abstract-bindings-hash": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.4.4.tgz",
-      "integrity": "sha512-SgT7+WAzas/S8OyGs018KRAkCZbCo9Xo1YQTMf2JmL30wLc8iR8vrtlBgd/noyesd9iOFKiroyrR19Zm3/qnpQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-bindings-hash/-/actor-abstract-bindings-hash-1.6.0.tgz",
+      "integrity": "sha512-wVrufnCM1sjUgoAx2BqA87MLI3TdspURZuLIei3+MqZCsxxTTf2BnYt9ctE/sjHF26R+S1s8v9oXXmYOr0hqog=="
     },
     "@comunica/actor-abstract-mediatyped": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.4.0.tgz",
-      "integrity": "sha512-30WSiLjDaZ7mkeRzbsoW91UHaWtfgYH54W7qIP9osntfFUQq6KbYGsmlnsDPSva+cmGralAb7g3HMqErBeFHgQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-1.6.0.tgz",
+      "integrity": "sha512-yHMsh04V3B33piprdR31uLGZqASL6n7LogdwkudtnjGX2ODLfeOk1NMxE9nsf3LE90TdCWn3aTeQTQNQmx0/9w==",
       "requires": {
         "lodash.mapvalues": "^4.6.0"
       }
     },
     "@comunica/actor-abstract-path": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.4.5.tgz",
-      "integrity": "sha512-NDFaA880vcpxnRZaZrOKi/8jN7bYc0cx07PZhMP59BcIvaLJA6V7BuJNegQeeKDPA0K/mkMsWztq6nsvLYHkuQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.6.0.tgz",
+      "integrity": "sha512-B16It0IJKIxolK5ePuZZGLhu4N+UHdWoZxxyFekur1te4o1/13q/01/cIgbSLiv1zUeLdk8FXVUAT6K4H4zVQA==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "asynciterator": "^2.0.1",
@@ -797,26 +797,26 @@
       }
     },
     "@comunica/actor-context-preprocess-rdf-source-identifier": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-rdf-source-identifier/-/actor-context-preprocess-rdf-source-identifier-1.5.4.tgz",
-      "integrity": "sha512-21vQ0T7YNqd8Xzew2Gbmyo3dG2BjRUWtpqWDheqlZn6mWoCzi6D66RFsNfM9Uz+QjxwSCXVtPwsdx5GXNXCNQA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-rdf-source-identifier/-/actor-context-preprocess-rdf-source-identifier-1.6.0.tgz",
+      "integrity": "sha512-PdFeE6NflVnnwr0ywD2RL8LkdnekF/3QX6I+tlCV7lUCAt8XZboFBLyTB08GuCJkEcGFT6k52NWgwkJlJR6low==",
       "requires": {
         "asyncreiterable": "^1.1.1"
       }
     },
     "@comunica/actor-http-memento": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.5.1.tgz",
-      "integrity": "sha512-0uqMxG7/82kG/RHSzVfGvZbs2e6II/j/Kj2Afhn1ouAbrJOIJU3BVtqJ0UfK16ipiVJPD6/YOz8fkaO2SArzpA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.6.0.tgz",
+      "integrity": "sha512-E2d1LEEo9xzeSJbPYeX8TWE3WS/5adftO6V4RZroleI0gjciDiTazKk8KvH/ubvUZybuR5CKFZT65sZ1lxAk7g==",
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "parse-link-header": "^1.0.1"
       }
     },
     "@comunica/actor-http-native": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.5.1.tgz",
-      "integrity": "sha512-IhH2CVf33pw5S35VSFIxefmkT8t04/7dqNtgeKNMH1PDlyeLqWsFk32KhZ0CwUr9Q/FaejhQK+pYTcTK3iEpOg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.6.0.tgz",
+      "integrity": "sha512-2N1atPHSOkgcw/LYT9s7mrH9d2NzYszwgYLA9abGjZiCyOsUBK46/pB5nY08BE7Vtbg8h5jhr4vUnxUZNVEBnw==",
       "requires": {
         "follow-redirects": "^1.5.1",
         "isomorphic-fetch": "^2.2.1",
@@ -832,102 +832,104 @@
       }
     },
     "@comunica/actor-init-sparql": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.5.4.tgz",
-      "integrity": "sha512-WFSVBlSUsU9jjnK33ur34427DzKRtKGU6FGp1GwlnflDigdypfgt1iCOp+al3mvruguqq/XgOY6brJfqleuRqw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.6.0.tgz",
+      "integrity": "sha512-wRKeJTYNEdiqZWvNQ+rOzZL2tUj5vZEaF2hyS7VzwRsQIyKM30c5n3II2sWtvzYRnxxowiQBozcU1uV8Z8oGNQ==",
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.4.4",
-        "@comunica/actor-abstract-mediatyped": "^1.4.0",
-        "@comunica/actor-context-preprocess-rdf-source-identifier": "^1.5.4",
-        "@comunica/actor-http-memento": "^1.5.1",
-        "@comunica/actor-http-native": "^1.5.1",
-        "@comunica/actor-optimize-query-operation-join-bgp": "^1.5.0",
-        "@comunica/actor-query-operation-ask": "^1.4.4",
-        "@comunica/actor-query-operation-bgp-empty": "^1.4.4",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.4.5",
-        "@comunica/actor-query-operation-bgp-single": "^1.4.4",
-        "@comunica/actor-query-operation-construct": "^1.4.4",
-        "@comunica/actor-query-operation-describe-subject": "^1.4.4",
-        "@comunica/actor-query-operation-distinct-hash": "^1.4.4",
-        "@comunica/actor-query-operation-extend": "^1.5.2",
-        "@comunica/actor-query-operation-filter-sparqlee": "^1.5.1",
-        "@comunica/actor-query-operation-from-quad": "^1.4.5",
-        "@comunica/actor-query-operation-join": "^1.4.4",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.5.1",
-        "@comunica/actor-query-operation-minus": "^1.4.4",
-        "@comunica/actor-query-operation-orderby-sparqlee": "^1.5.1",
-        "@comunica/actor-query-operation-path-alt": "^1.4.5",
-        "@comunica/actor-query-operation-path-inv": "^1.4.5",
-        "@comunica/actor-query-operation-path-link": "^1.4.5",
-        "@comunica/actor-query-operation-path-nps": "^1.4.5",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.4.5",
-        "@comunica/actor-query-operation-path-seq": "^1.4.5",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.4.5",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.4.5",
-        "@comunica/actor-query-operation-project": "^1.4.4",
-        "@comunica/actor-query-operation-quadpattern": "^1.5.4",
-        "@comunica/actor-query-operation-reduced-hash": "^1.4.5",
-        "@comunica/actor-query-operation-service": "^1.4.4",
-        "@comunica/actor-query-operation-slice": "^1.4.4",
-        "@comunica/actor-query-operation-sparql-endpoint": "^1.5.4",
-        "@comunica/actor-query-operation-union": "^1.4.4",
-        "@comunica/actor-query-operation-values": "^1.4.4",
-        "@comunica/actor-rdf-dereference-http-parse": "^1.5.1",
-        "@comunica/actor-rdf-dereference-paged-next": "^1.4.5",
-        "@comunica/actor-rdf-join-nestedloop": "^1.4.4",
-        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.4.0",
-        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.4.0",
-        "@comunica/actor-rdf-metadata-primary-topic": "^1.4.0",
-        "@comunica/actor-rdf-metadata-triple-predicate": "^1.4.0",
-        "@comunica/actor-rdf-parse-jsonld": "^1.5.4",
-        "@comunica/actor-rdf-parse-n3": "^1.4.3",
-        "@comunica/actor-rdf-parse-rdfxml": "^1.4.3",
-        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.5.4",
-        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.5.4",
-        "@comunica/actor-rdf-resolve-quad-pattern-file": "^1.5.4",
-        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.5.4",
-        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.5.4",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.5.4",
-        "@comunica/actor-rdf-serialize-n3": "^1.4.3",
-        "@comunica/actor-rdf-source-identifier-file-content-type": "^1.5.1",
-        "@comunica/actor-rdf-source-identifier-hypermedia-qpf": "^1.5.1",
-        "@comunica/actor-rdf-source-identifier-sparql": "^1.5.1",
-        "@comunica/actor-sparql-parse-algebra": "^1.5.3",
-        "@comunica/actor-sparql-parse-graphql": "^1.5.3",
-        "@comunica/actor-sparql-serialize-json": "^1.4.4",
-        "@comunica/actor-sparql-serialize-rdf": "^1.4.4",
-        "@comunica/actor-sparql-serialize-simple": "^1.4.4",
-        "@comunica/actor-sparql-serialize-sparql-json": "^1.4.4",
-        "@comunica/actor-sparql-serialize-sparql-xml": "^1.4.4",
-        "@comunica/actor-sparql-serialize-stats": "^1.4.4",
-        "@comunica/actor-sparql-serialize-table": "^1.4.4",
-        "@comunica/actor-sparql-serialize-tree": "^1.4.4",
-        "@comunica/bus-context-preprocess": "^1.4.0",
-        "@comunica/bus-http": "^1.5.1",
-        "@comunica/bus-init": "^1.4.0",
-        "@comunica/bus-optimize-query-operation": "^1.5.0",
-        "@comunica/bus-query-operation": "^1.4.4",
-        "@comunica/bus-rdf-dereference": "^1.4.0",
-        "@comunica/bus-rdf-dereference-paged": "^1.4.0",
-        "@comunica/bus-rdf-join": "^1.4.4",
-        "@comunica/bus-rdf-metadata": "^1.4.0",
-        "@comunica/bus-rdf-metadata-extract": "^1.4.0",
-        "@comunica/bus-rdf-parse": "^1.4.2",
-        "@comunica/bus-rdf-resolve-hypermedia": "^1.5.4",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.5.4",
-        "@comunica/bus-rdf-serialize": "^1.4.0",
-        "@comunica/bus-rdf-source-identifier": "^1.5.1",
-        "@comunica/bus-sparql-parse": "^1.4.0",
-        "@comunica/bus-sparql-serialize": "^1.4.4",
+        "@comunica/actor-abstract-bindings-hash": "^1.6.0",
+        "@comunica/actor-abstract-mediatyped": "^1.6.0",
+        "@comunica/actor-context-preprocess-rdf-source-identifier": "^1.6.0",
+        "@comunica/actor-http-memento": "^1.6.0",
+        "@comunica/actor-http-native": "^1.6.0",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^1.6.0",
+        "@comunica/actor-query-operation-ask": "^1.6.0",
+        "@comunica/actor-query-operation-bgp-empty": "^1.6.0",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.6.0",
+        "@comunica/actor-query-operation-bgp-single": "^1.6.0",
+        "@comunica/actor-query-operation-construct": "^1.6.0",
+        "@comunica/actor-query-operation-describe-subject": "^1.6.0",
+        "@comunica/actor-query-operation-distinct-hash": "^1.6.0",
+        "@comunica/actor-query-operation-extend": "^1.6.0",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.6.0",
+        "@comunica/actor-query-operation-from-quad": "^1.6.0",
+        "@comunica/actor-query-operation-join": "^1.6.0",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.6.0",
+        "@comunica/actor-query-operation-minus": "^1.6.0",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.6.0",
+        "@comunica/actor-query-operation-path-alt": "^1.6.0",
+        "@comunica/actor-query-operation-path-inv": "^1.6.0",
+        "@comunica/actor-query-operation-path-link": "^1.6.0",
+        "@comunica/actor-query-operation-path-nps": "^1.6.0",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.6.0",
+        "@comunica/actor-query-operation-path-seq": "^1.6.0",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.6.0",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.6.0",
+        "@comunica/actor-query-operation-project": "^1.6.0",
+        "@comunica/actor-query-operation-quadpattern": "^1.6.0",
+        "@comunica/actor-query-operation-reduced-hash": "^1.6.0",
+        "@comunica/actor-query-operation-service": "^1.6.0",
+        "@comunica/actor-query-operation-slice": "^1.6.0",
+        "@comunica/actor-query-operation-sparql-endpoint": "^1.6.0",
+        "@comunica/actor-query-operation-union": "^1.6.0",
+        "@comunica/actor-query-operation-values": "^1.6.0",
+        "@comunica/actor-rdf-dereference-http-parse": "^1.6.0",
+        "@comunica/actor-rdf-dereference-paged-next": "^1.6.0",
+        "@comunica/actor-rdf-join-nestedloop": "^1.6.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.6.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.6.0",
+        "@comunica/actor-rdf-metadata-primary-topic": "^1.6.0",
+        "@comunica/actor-rdf-metadata-triple-predicate": "^1.6.0",
+        "@comunica/actor-rdf-parse-jsonld": "^1.6.0",
+        "@comunica/actor-rdf-parse-n3": "^1.6.0",
+        "@comunica/actor-rdf-parse-rdfxml": "^1.6.0",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.6.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.6.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-file": "^1.6.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.6.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.6.0",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.6.0",
+        "@comunica/actor-rdf-serialize-n3": "^1.6.0",
+        "@comunica/actor-rdf-source-identifier-file-content-type": "^1.6.0",
+        "@comunica/actor-rdf-source-identifier-hypermedia-qpf": "^1.6.0",
+        "@comunica/actor-rdf-source-identifier-sparql": "^1.6.0",
+        "@comunica/actor-sparql-parse-algebra": "^1.6.0",
+        "@comunica/actor-sparql-parse-graphql": "^1.6.0",
+        "@comunica/actor-sparql-serialize-json": "^1.6.0",
+        "@comunica/actor-sparql-serialize-rdf": "^1.6.0",
+        "@comunica/actor-sparql-serialize-simple": "^1.6.0",
+        "@comunica/actor-sparql-serialize-sparql-json": "^1.6.0",
+        "@comunica/actor-sparql-serialize-sparql-xml": "^1.6.0",
+        "@comunica/actor-sparql-serialize-stats": "^1.6.0",
+        "@comunica/actor-sparql-serialize-table": "^1.6.0",
+        "@comunica/actor-sparql-serialize-tree": "^1.6.0",
+        "@comunica/bus-context-preprocess": "^1.6.0",
+        "@comunica/bus-http": "^1.6.0",
+        "@comunica/bus-http-invalidate": "^1.6.0",
+        "@comunica/bus-init": "^1.6.0",
+        "@comunica/bus-optimize-query-operation": "^1.6.0",
+        "@comunica/bus-query-operation": "^1.6.0",
+        "@comunica/bus-rdf-dereference": "^1.6.0",
+        "@comunica/bus-rdf-dereference-paged": "^1.6.0",
+        "@comunica/bus-rdf-join": "^1.6.0",
+        "@comunica/bus-rdf-metadata": "^1.6.0",
+        "@comunica/bus-rdf-metadata-extract": "^1.6.0",
+        "@comunica/bus-rdf-parse": "^1.6.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^1.6.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.6.0",
+        "@comunica/bus-rdf-serialize": "^1.6.0",
+        "@comunica/bus-rdf-source-identifier": "^1.6.0",
+        "@comunica/bus-sparql-parse": "^1.6.0",
+        "@comunica/bus-sparql-serialize": "^1.6.0",
         "@comunica/core": "^1.4.0",
-        "@comunica/logger-pretty": "^1.4.0",
-        "@comunica/logger-void": "^1.4.0",
+        "@comunica/logger-pretty": "^1.6.0",
+        "@comunica/logger-void": "^1.6.0",
+        "@comunica/mediator-all": "^1.6.0",
         "@comunica/mediator-combine-pipeline": "^1.4.0",
         "@comunica/mediator-combine-union": "^1.4.0",
         "@comunica/mediator-number": "^1.4.1",
-        "@comunica/mediator-race": "^1.4.0",
-        "@comunica/runner": "^1.4.4",
-        "@comunica/runner-cli": "^1.4.4",
+        "@comunica/mediator-race": "^1.6.0",
+        "@comunica/runner": "^1.6.0",
+        "@comunica/runner-cli": "^1.6.0",
         "asyncreiterable": "^1.1.1",
         "minimist": "^1.2.0",
         "negotiate": "^1.0.1",
@@ -937,30 +939,30 @@
       }
     },
     "@comunica/actor-optimize-query-operation-join-bgp": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.5.0.tgz",
-      "integrity": "sha512-PBMbOahhuHqUqTjqqqqibS6SorJGihxTPSEiSpJ6cAENWXwKqLzc1/M+5p4ToGOK1t7JrlsPcwbBmxqlWZLySg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.6.0.tgz",
+      "integrity": "sha512-MpgQaTd1xBZHUeNKMbafNBtEX1JBopm+cEj8coW/PD4l0WYUHphftCY79+etLH8WfqBWEgwC8auUvobdM6qbkQ==",
       "requires": {
         "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-ask": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.4.4.tgz",
-      "integrity": "sha512-SXXik/wfFL8fQaeZ6AtMTi3YOprWsWa9p+bVqf+94fLZV1a0X2EUXUjSbLUm4EgoIW9q23zbqkuBu8hv1VR2NA=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-1.6.0.tgz",
+      "integrity": "sha512-Dyw1RPrBmBJKv0Ga2JL42a+yhgAAm5fKRxzmViOzcL3I/A7fVPWtCmzgFa97gVI1Hx/9ll+WthM5wPPD4KrNWw=="
     },
     "@comunica/actor-query-operation-bgp-empty": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.4.4.tgz",
-      "integrity": "sha512-TcgsQT8RPZkOJrzWme8EnEyACOpLPXaL+20iGxYYkfEO2dprz9nDNobOBCiCVUU4muZPUEkKOK6JDAFTlk26ww==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-empty/-/actor-query-operation-bgp-empty-1.6.0.tgz",
+      "integrity": "sha512-n0cICSVdkQljo5oOIOc18qil4L5ivtc89vXOl2qlElKuDs6lDmDR4aCUwFQxA4YiMikIZZd/646mTZp8EdWDuQ==",
       "requires": {
         "asynciterator": "^2.0.1"
       }
     },
     "@comunica/actor-query-operation-bgp-left-deep-smallest": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.4.5.tgz",
-      "integrity": "sha512-5IVoDX0upYMM0p8ibnxeqtrnIvhJPTitsEB240Jr+cMHqNYLwcSncwh9pU7tGKtqhzYgeYZKXEp0Ju+9aviAKQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.6.0.tgz",
+      "integrity": "sha512-u6lkKf0xBAYCK61oC5EGsEAr+GjJ57B/kDimwlURMqo2rCX9GDxWo2KoyL+IGTWT+U+hySithUbODSdGE5X8MQ==",
       "requires": {
         "asynciterator-promiseproxy": "^2.0.0",
         "lodash.uniq": "^4.5.0",
@@ -969,14 +971,14 @@
       }
     },
     "@comunica/actor-query-operation-bgp-single": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.4.4.tgz",
-      "integrity": "sha512-3S9S5q/yICpSn4WsqvEPUYx1+Tm/UAx0yzYK+B6nj4Ip/+ZRF67NeZSGPbH1N97m9jBAJIimptAodQocU9D2yA=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-single/-/actor-query-operation-bgp-single-1.6.0.tgz",
+      "integrity": "sha512-ikaqR7zKoZO4cmIGquJeQgABwue9A/Qz+8Y9gAoJFUE2kPst9vjzOirHOcizsR8u5ZSf3HooFIJ5fW+SSNIeaw=="
     },
     "@comunica/actor-query-operation-construct": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.4.4.tgz",
-      "integrity": "sha512-HD32kHIbPgi+ifko0T7tD5dyxHomIXxAD/ud1EJLkKMkl7/4AQXdM7AdcfhUAz57QS3yFRebED2c2hGTzuCDsg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-1.6.0.tgz",
+      "integrity": "sha512-Ws6cv4BsopHlV/q9rH/8OUgnGdaQPAizK/CHt6YYpuvYFSR0kDk+k79Kqh4PnG1rXzf6Go/micH0rb6qiLQGyw==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "asynciterator": "^2.0.1",
@@ -984,124 +986,124 @@
       }
     },
     "@comunica/actor-query-operation-describe-subject": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.4.4.tgz",
-      "integrity": "sha512-EAGX3KvhuQPpxatQTfuy1FXziTBQe04bcpaETIKqdE9zrxwTsSpp0IjoOtUJZU8VFHx0OOr8GqfD7mrRA6x/rg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-1.6.0.tgz",
+      "integrity": "sha512-OAvLunBBBi/L5fjbkhwmBydmEY7WHdvraheZjJNGslnWcRQOy067LkObjJdGi5Sz8MlA9FfII0m+dOSRk80IBA==",
       "requires": {
-        "@comunica/actor-query-operation-union": "^1.4.4",
+        "@comunica/actor-query-operation-union": "^1.6.0",
         "@rdfjs/data-model": "^1.1.1",
         "asynciterator-union": "^2.1.1"
       }
     },
     "@comunica/actor-query-operation-distinct-hash": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.4.4.tgz",
-      "integrity": "sha512-CNSlO8OmoQy3zaBokvSlL3tqUmntcII9M7Y4Mzar9DxhSYeOB9k8uEIy5loKWze9u1/DQnOs6C/3YuxlopG1xg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-1.6.0.tgz",
+      "integrity": "sha512-Smranjp5pNkLN4nt4dDpgKuYoeKGX8WXQUTbO129GhSIfkuh2IUDCqgRdp3xyg245BYJfdpfBKhmstmXkjWvUw==",
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.4.4",
+        "@comunica/actor-abstract-bindings-hash": "^1.6.0",
         "json-stable-stringify": "^1.0.1"
       }
     },
     "@comunica/actor-query-operation-extend": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.5.2.tgz",
-      "integrity": "sha512-aYgl6sQCmk7NsiizgpH9d5gMMisXjxy8GmUNh5NvvvbpaodlqojVJb4rY6IfKcJpAKzUUODQ5Vme9uPAbWjlZQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.6.0.tgz",
+      "integrity": "sha512-mN1WJRzyokDl1mbdHSWKj1g9Mo8ne8LDtjSQ236RgGmBn2Y3iqHX5wpzgsdPHbY8ptsE8TC6aZVi5Jk2k+wuEA==",
       "requires": {
-        "sparqlee": "0.0.2"
+        "sparqlee": "0.1.0"
       }
     },
     "@comunica/actor-query-operation-filter-sparqlee": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.5.1.tgz",
-      "integrity": "sha512-BoFncqHwKcPW4MoH4TT+/6oYDjl/v/u7GpP9HOCcwjrgDbcuqt1wn5hYsMvs2cj30ECT9t5UuaHuYnoQum/JDw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.6.0.tgz",
+      "integrity": "sha512-DoKLa+Q+c1epiwkMoHLFqVfhnc7wo5uDY1PXP/a5uBZQfj/yyQLfhfwUuZEvEAEIh5w1L47aglcDU7nExLQ66A==",
       "requires": {
-        "sparqlee": "0.0.2"
+        "sparqlee": "0.1.0"
       }
     },
     "@comunica/actor-query-operation-from-quad": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.4.5.tgz",
-      "integrity": "sha512-TG7eDrrQ1XS+7Ut5pPExikdTipJSJICEmA0Nw+B7H5WjKEdND/GeMsvqLqk+u1AiHHJiR3kfjso5fEnzM4OUyw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.6.0.tgz",
+      "integrity": "sha512-PwC9A7ewC2NSQcoM/vvt9F+9R5UlNkd+ZIH1g13A6RLPzII2dwgmLJWydf6rGQ2RNBlRKyZE+l4542/9t8iWQA==",
       "requires": {
         "lodash.find": "^4.6.0",
         "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-join": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.4.4.tgz",
-      "integrity": "sha512-xTxusuDuLbE2mSxxmtPUInAkuKwcPgTkCZj7jif/j934qdo7Ar1lIZwQJL0AwgOdmMODn/9Z6/oiIrLMR/xKBA=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-1.6.0.tgz",
+      "integrity": "sha512-BO3mVi76d9uPOoYJbP7+cFbUNDA0/4jAf3MAoe5N470Cax4wNeiFvoAWsW3Q9e27wxmqpPvj9o94HtcQX/s73A=="
     },
     "@comunica/actor-query-operation-leftjoin-nestedloop": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.5.1.tgz",
-      "integrity": "sha512-d4XeHYaaPG0Jt0yl34GbYUBeRFSw/G4lYa+u2SRRBFVDP6crrtqC0zQjNyFoL5cyZj5W64pRK5DpHNj8SJby2w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.6.0.tgz",
+      "integrity": "sha512-mXNonOCCJgnE8nHqpQvh+zvS3sAXn8FCyBX0Ix9b7LQ9d9XBFH+084Wf8YP3agz0Eyqm3QZRUOnECY87kKKyWw==",
       "requires": {
-        "sparqlee": "0.0.2"
+        "sparqlee": "0.1.0"
       }
     },
     "@comunica/actor-query-operation-minus": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.4.4.tgz",
-      "integrity": "sha512-eB3bNyKxtPZu73zgg9fuKbtQERHIzUX3Y7RTCmejQ77wZo1SwEsIlEaMoudqX1+nlj31fwtqb/NtYbR6X0Axxg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-1.6.0.tgz",
+      "integrity": "sha512-K9uC5L7kXoXX4p8DmsWERwWFsjF3K3T0lHrgmDjsmYMSIXAAEzb2tfJipQFs9nplmtTJOjwL4KiMKl/n4boAzw==",
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.4.4",
+        "@comunica/actor-abstract-bindings-hash": "^1.6.0",
         "asynciterator-promiseproxy": "^2.0.0"
       }
     },
     "@comunica/actor-query-operation-orderby-sparqlee": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.5.1.tgz",
-      "integrity": "sha512-28e94juVJvEVIvTD0zDqzFpZo2V6csrGZ0qv1NU2HVOLdGNlXjoBPd/7K4kkkdeDC6h8zPXFeFUnnEIX+c2nsw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.6.0.tgz",
+      "integrity": "sha512-LcrCjvFE6UbTLbYZ1YtyfDYyzPt4Tye7V/GuqfVROni7oLuuoJ5A4wRAcSKxZ6sBUGkzxERQQk82W7Hc0byFSA==",
       "requires": {
         "rdf-string": "^1.3.1",
-        "sparqlee": "0.0.2"
+        "sparqlee": "0.1.0"
       }
     },
     "@comunica/actor-query-operation-path-alt": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.4.5.tgz",
-      "integrity": "sha512-3x3GLHISOtYwfHBudCz6TZGQNqB0jnnV/CYRIB61gnzLTDaI5Ts1bBNRklNQ77kjENq9EA02qOxXQnBQzbGQNg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.6.0.tgz",
+      "integrity": "sha512-ssns/3oSHLpVqVFoxJa7/EVn9q1L3RzmcLQGl3YQjSz3v/HmMGXBU3F4QhoI4JvP0O/WDqiJvKb8z61fBWcfVw==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.5",
+        "@comunica/actor-abstract-path": "^1.6.0",
         "asynciterator-union": "^2.1.1",
         "lodash.uniq": "^4.5.0",
         "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-inv": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.4.5.tgz",
-      "integrity": "sha512-Ex/w1omPPo/HPqLPP1D+Weof60AEs5sYUe5PBaUwHnAiJycqyD9fMvFFgl08N5vg/EmaVZB0d5dgGSzgV5WE2A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.6.0.tgz",
+      "integrity": "sha512-kZXLb5z2MOgXECueONd+hFagtG9ZOfvux8soSRp02tm89LA/l87dCv9DIxk8QUOrmwG7l3ZJ0SSk149nhe+x6Q==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.5"
+        "@comunica/actor-abstract-path": "^1.6.0"
       }
     },
     "@comunica/actor-query-operation-path-link": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.4.5.tgz",
-      "integrity": "sha512-soXrhOH0Azc0QNhnlnFfqxMXhba2GNEDV3wOXWxQNgf1mc2SV1kkaTHzBgbWuEL3I4wzzMp2EbrWdZSzanPfxw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.6.0.tgz",
+      "integrity": "sha512-I4/PT3XB4Yc9VcDBHutroP+Lv20Z7GkxHMLmezkAFC6z14MivmGC+/I+zc5wJSxETHf5J+sv24Z5l4mGdvnNdA==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.5",
+        "@comunica/actor-abstract-path": "^1.6.0",
         "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-nps": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.4.5.tgz",
-      "integrity": "sha512-vHl9GznWT0pW+KR/f9INfDo119OBjO1FLZxPlwWivo273WQtuVFfWQkL3iZToGIyUy7Aq3pLSh5kcvtRMIGj9w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.6.0.tgz",
+      "integrity": "sha512-rPTugkghu0KxtG0IBb2Nj3kG12rdAnHU7tqReei3BeHS3Eyn8yUA/AV6QJCsyZh4wkCVkNYuEweqWeDf62Lxsg==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.5",
+        "@comunica/actor-abstract-path": "^1.6.0",
         "rdf-string": "^1.3.1",
         "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-one-or-more": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.4.5.tgz",
-      "integrity": "sha512-Tm+tdT4Zkvn/JZEFZ+X2nUc/nNFmKV1t+I3SaPSJVv3Z2/2CyjtA4SsuWaugo3IW5N9uDtIeOxGy4mhopo8myQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.6.0.tgz",
+      "integrity": "sha512-lVkPSGPnyYnJZEzfcnmT6Mm+HUMQCUrh88VC7C+s2NShrXeR3zY6Fndp29w+SKdGAI/m+Keb2W/6BRAfU68GMA==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.5",
+        "@comunica/actor-abstract-path": "^1.6.0",
         "asynciterator": "^2.0.1",
         "asynciterator-promiseproxy": "^2.0.0",
         "rdf-string": "^1.3.1",
@@ -1109,47 +1111,47 @@
       }
     },
     "@comunica/actor-query-operation-path-seq": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.4.5.tgz",
-      "integrity": "sha512-ihPQFDFPgDGYsBrwYcsJLv0hyDrJDYda6Dg17mnEtKGtk/TBn65Ev1A+YX1B3DPl5uUDWcEwrwZuIHzDrdssUw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.6.0.tgz",
+      "integrity": "sha512-Rejb9L7LwjXfRN3x+HAmt83ephPoQvL+JhzdZxXUIueBbjyM/i1sw7e9Zxt/L7UTR3fjoUgIXfyYb9146/PqWQ==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.5",
+        "@comunica/actor-abstract-path": "^1.6.0",
         "rdf-string": "^1.3.1",
         "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.4.5.tgz",
-      "integrity": "sha512-RB+uoxnuvfCpoL3dzzlULrwqGfYPRQ4gSKjTKtkPm3yQEKzqoFp9q6HxGIilk8l1MddEnaHd30PnN/l3csarIg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.6.0.tgz",
+      "integrity": "sha512-QKefgFQhTvGOeWDcEvLRTiz1RdhDtkowO+eMf2rrBtYlHDtZPZcXuL0KevtGE/LoD/9v3ZcSeu/1k7uZFGfXtQ==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.5",
+        "@comunica/actor-abstract-path": "^1.6.0",
         "rdf-string": "^1.3.1",
         "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.4.5.tgz",
-      "integrity": "sha512-j4cTlPNDRKUybM5L4Uzqlid4Z4MhxwDhpGqF61v3Xs8icBO4F9JQGmgqNZy/CmT0QSdLycVfX/ubcNg69fb50w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.6.0.tgz",
+      "integrity": "sha512-nHNIppyxojo5vHimNOEtoOJji5mGm5YyXnVRUMbnbFW7DDEjUjScZMKohWJzl0ilYNFQtbb0ecO+vEWlss6b3w==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.5",
+        "@comunica/actor-abstract-path": "^1.6.0",
         "asynciterator": "^2.0.1",
         "rdf-string": "^1.3.1"
       }
     },
     "@comunica/actor-query-operation-project": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.4.4.tgz",
-      "integrity": "sha512-3iDB23M5/cYlyK+Ce1T9HuhKTT2e3iQGyRpnoL83PWa3NrRNy6J/5MYbKD6rB66cL28XSMLPfHghG7A2kpvv3g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-1.6.0.tgz",
+      "integrity": "sha512-ogfhwxDKEyGYY1Sf4vUrXK62St4dFiHtxXobegDR1cYW+AnnFK8+wzQo7V1zZIkBq7KHbylYbyPaxWtB32Ua0g==",
       "requires": {
         "rdf-string": "^1.3.1"
       }
     },
     "@comunica/actor-query-operation-quadpattern": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.5.4.tgz",
-      "integrity": "sha512-LjLfIwOD2uoTMVOOWiXAaA04/drVXWcf6gq1rc4rDbxcJdAHGrbTpZi61GwHP4vCCk7f2U6I/64fI6BLrAjo4g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.6.0.tgz",
+      "integrity": "sha512-jJO+0Euq2n5RthPKpf+1MDrTBTcAlZDfl5YKjKFKLYR1QMwo7NCBrAXljxXJTslLmrTFjFkISR6ds1Ee4oY6LQ==",
       "requires": {
         "asynciterator-promiseproxy": "^2.0.0",
         "rdf-string": "^1.3.1",
@@ -1157,31 +1159,31 @@
       }
     },
     "@comunica/actor-query-operation-reduced-hash": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.4.5.tgz",
-      "integrity": "sha512-Nl8Uv1gRTAeZxvLOW6hlTUV2tm6qQtkanUgjxqNjoLSRTmOe7JqcQiKZg9vjgW82d8HUXYmzgvzMMezm3DAkaQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.6.0.tgz",
+      "integrity": "sha512-77sSF1Le6mkgpjkWDsnvnwJUsUbOg4xJSMgZ6i6WATQLVN4xBZ3erve/jm2p2gmWUXndvnam76/N3E1DSs2c0g==",
       "requires": {
-        "@comunica/actor-abstract-bindings-hash": "^1.4.4",
+        "@comunica/actor-abstract-bindings-hash": "^1.6.0",
         "lru-cache": "^5.1.1"
       }
     },
     "@comunica/actor-query-operation-service": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.4.4.tgz",
-      "integrity": "sha512-NsEwoFrvHbRtJj+G9ZsmtPxISb+zmCjaLyGFHkpfT4NnqAeASNZWlakckRXm4mNSl3QLKvkF8rRlzVRxG+NGVQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-1.6.0.tgz",
+      "integrity": "sha512-ZYPzs9ohFan+6EonXA0qTGS6HS/D3r6aefRiqLIAO21lUXGK81xLaI1UZojeoNFpHWeF1OEv+H9g99IFxtKETA==",
       "requires": {
         "asynciterator": "^2.0.1"
       }
     },
     "@comunica/actor-query-operation-slice": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.4.4.tgz",
-      "integrity": "sha512-Ta9l2eOqgC1i2hOONWnlaUJ5EtDKEFJPV7G3zC7XCl0V4XBKXyMqpkXy9LXOJbPoMP1VvHdxoLNJ05xOSjHvtQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-1.6.0.tgz",
+      "integrity": "sha512-GGpTgkzC74HProgo8rvrLWyibDaUcjvGgMb+F3Qp98Nd91FdiKMiY3txYWuXAmCXiKopJB6dSZ0bxw48yYsSLw=="
     },
     "@comunica/actor-query-operation-sparql-endpoint": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.5.4.tgz",
-      "integrity": "sha512-QCxckYzgiyOH+zvB0DyCEPYSW8Ls6Ebcz0Bx9Ez15IHyu5CSke4WtWZ+947Jw7ZOmcnM/yoVDJ+czsmvJ1Yahg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.6.0.tgz",
+      "integrity": "sha512-HFkOCqA609+RD0aXId0/mXvdtdEGnPn/noKa1VxeAumxmN96r7Klj5j4DNM1soXgBacj5Ry0Bg7Pi/7i9ZJMGg==",
       "requires": {
         "@comunica/utils-datasource": "^1.5.4",
         "arrayify-stream": "^1.0.0",
@@ -1193,49 +1195,49 @@
       }
     },
     "@comunica/actor-query-operation-union": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.4.4.tgz",
-      "integrity": "sha512-tCyYbT/0fKnmV3al2YSdytrfq9pgI5FrIW7nMKyFL5HiHQTmbDRPbCJxVeOq++gtRWVUG64p/RY2or8/OpCUeQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-1.6.0.tgz",
+      "integrity": "sha512-gJ/LpKakGoOv6KCCCI3FJTH+KLFzEokX4G8zb++PaxX+kZXtNbKBfRkU8Y1KmnNqARtH+HOdsFsU0Z/0WS7cAg==",
       "requires": {
         "asynciterator-union": "^2.1.1",
         "lodash.union": "^4.6.0"
       }
     },
     "@comunica/actor-query-operation-values": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.4.4.tgz",
-      "integrity": "sha512-xsutv0JdD1Xjxfvnf7KnJnV6DNv2+Gmb5nzy3KnDd5QJ8d/tB27dOR0jiS/K/sVJWlKQPZ8QMbritFh/WrB/Vg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-1.6.0.tgz",
+      "integrity": "sha512-LjRnWA6wgD9ZdKzAOpqjPf2K9FbY3e4/xqddYNJrQZvRN4YQcTeptO14Jz+4b+7CbRdc1Kkp04qxKvU/kCjFWQ==",
       "requires": {
         "asynciterator": "^2.0.1",
         "rdf-string": "^1.3.1"
       }
     },
     "@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.5.1.tgz",
-      "integrity": "sha512-hXqV3VOf0l6en/1LPODll0rT4kO1TMNYilAGP6aCa6NXdY0NOlqAJ4VgUkGuJUnfS09T/gYaU4R/KjZxzic58g=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.6.0.tgz",
+      "integrity": "sha512-Vp4eQqOFtBuUB7eBzpndqevCRQaCiFf0uJV60kPfXuKF3a/pukqwaoPKRHmIr3fxAyA56u+qaKR/3UphOypPtQ=="
     },
     "@comunica/actor-rdf-dereference-paged-next": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-paged-next/-/actor-rdf-dereference-paged-next-1.4.5.tgz",
-      "integrity": "sha512-GJNBAB90XFExc5HKBs0oCUr749rHGQCjvZxWRH5CM6UFILfXvDt1GUvmWxWlVa4kcwqJQMvuVZioXvo9UqHMKg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-paged-next/-/actor-rdf-dereference-paged-next-1.6.0.tgz",
+      "integrity": "sha512-BrpU3vZwuhyG+jdzFBBx3vnyILZa/l54yiJ1YXNIrmpOILo4BeyXLTEX36UdfV/S3TYm1PkfiB4nx7Jr94Tiag==",
       "requires": {
         "asynciterator": "^2.0.1",
         "lru-cache": "^5.1.1"
       }
     },
     "@comunica/actor-rdf-join-nestedloop": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.4.4.tgz",
-      "integrity": "sha512-6RVl4lVGij1iElxBn3DeWE4u2K7N0KGMRi4OdjCycE+L8ihKvM0Mg/WtHf7qK5tyKMWIlVEUYDS1MvG5ZcaScw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-nestedloop/-/actor-rdf-join-nestedloop-1.6.0.tgz",
+      "integrity": "sha512-+G24rZrvKhhSddu2Ybe5KFKJ8/uh9cq0TvLRsScv4hdH2E60n8rVT4heJya3RgoYHPNxINiVEzDVYyk3MGUC1Q==",
       "requires": {
         "asyncjoin": "^0.3.0"
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-controls": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.4.0.tgz",
-      "integrity": "sha512-haLNX+21KyrTTioMDrbDhG6SMfyUUYXLXoE8oZUwiGJOSzkkv2vcLmyaLEr+mgmalQ+LVLV/9ozmoWQxpjwA7w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-1.6.0.tgz",
+      "integrity": "sha512-jFrkFrb7OplxAR47IEpqIx5n1wun03Kqe3VZobzL13CRPvcNe9l5nAmgR83oRO9xgA3ZLPELi8QCu1ldoc+i2A==",
       "requires": {
         "lodash.assign": "^4.2.0",
         "lodash.flatten": "^4.4.0",
@@ -1245,24 +1247,24 @@
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-count": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.4.0.tgz",
-      "integrity": "sha512-R1rvQBdzYApuikxdJj02rw+cAPzu9nXqJ8n+mTh7E8uXW1hFy9p+cDJBfTFOT4Ux/dNwxalTMz4y7WHdgRXlKQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-1.6.0.tgz",
+      "integrity": "sha512-TsyPqnPzKejLtrjdQzZHu0aVPt7dX+B90VJF/HNAf6INXv8bFtAf78XaRwSX03PnvfG4pE/vODW3sDJWt2tr+g=="
     },
     "@comunica/actor-rdf-metadata-primary-topic": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.4.0.tgz",
-      "integrity": "sha512-yUdJBKwL53M1adz22y4gxGm2PtIudD2X1Jis9tfIrJV2p+qWLZUVmtpJYEmSvJjdoRoYe4LwGDZ209P2mUZTiQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-1.6.0.tgz",
+      "integrity": "sha512-B3ATHdpkm/E77CytYRmudaqisyAzB+NjnG7+PARmU8aCYnG9jfGHL5Prk5GLWLZZ/eWa1CZ5+Iec+A+bN4661g=="
     },
     "@comunica/actor-rdf-metadata-triple-predicate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-triple-predicate/-/actor-rdf-metadata-triple-predicate-1.4.0.tgz",
-      "integrity": "sha512-myi1b1Rz/5T22CBbklybJdqFTwUH4UJmPCP+YSUQ3JgJLnvBocRQW2PSNe7CgivWUyM/VGqoXD22SlaVaeIRZw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-triple-predicate/-/actor-rdf-metadata-triple-predicate-1.6.0.tgz",
+      "integrity": "sha512-6vUmz1gREm5XP+qOS2efqUQ5FWfgN59PaHq0WRmw9aljsRe1x6v5L6pBpArIwl3bp6I0+1XVSacbX8IbDCmxtg=="
     },
     "@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.5.4.tgz",
-      "integrity": "sha512-LEMls07dg9kPcTQVARI+9fNIb8peGCjucafi1BVpMdUfCo6UeiQJZlZEX9fkaC2aVFfS1UyXnm8WJ6Za09ymkQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.6.0.tgz",
+      "integrity": "sha512-yKc5WTgdhSV2IOzl9Gd4Bj4f6MWaosXFqgBAZhttlFBpwaB1yPyNZqchwKw0nevf89J90lJ6dLncEOf8SuEYag==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "jsonld": "^1.5.0",
@@ -1271,25 +1273,25 @@
       }
     },
     "@comunica/actor-rdf-parse-n3": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.4.3.tgz",
-      "integrity": "sha512-DyblIe8G06AuPJ7LZnZGU9ngCZZX/10LvN3dGtDu0lsshSezXVnkF8P/If0CM13uYyXUoQ2RdQgi+TO/TaLSaQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-1.6.0.tgz",
+      "integrity": "sha512-JITiOgk3FZ2sK4+ag+4Hd62mQXtMQiAG3TTa/gla++pYZEt6lXcsQj/EICG1NcBdg+7jtZQrTnoxlO3Roqb98A==",
       "requires": {
         "n3": "^1.0.0"
       }
     },
     "@comunica/actor-rdf-parse-rdfxml": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.4.3.tgz",
-      "integrity": "sha512-BQx8otpEoWCHspnVg0uK6X35vF5R0EDClgZrYsN80xq4IcyibDTj5dPNQdabXKWAIPAmUS7kTqDsGkvlhYPT/g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-1.6.0.tgz",
+      "integrity": "sha512-Z/WAnbX7W7P60nz70P6A7BUPzXa/qOeajBfewznAxFq35EKoNQ8EdjDyhekDYn8EGVdEuQCDiY45fv38JlSsrg==",
       "requires": {
         "rdfxml-streaming-parser": "^1.1.0"
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-qpf": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.5.4.tgz",
-      "integrity": "sha512-RjKscMWCqYNM3RraqRzp4l40acASoVI08bRpkoDjR8/HGfHiW9YMDveBIuKK/0Khvo0US25V1iIUWA4odZDUIg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.6.0.tgz",
+      "integrity": "sha512-30xDgdq2gpv5uUuHp6Pr9V7Zrt3N/fc9Iw1qSBeGHqX9qpWn4pH4up7zLiUvTF1NbU+C8HP/RYyQqWTwPzeOHw==",
       "requires": {
         "@rdfjs/data-model": "^1.1.0",
         "asynciterator-promiseproxy": "^2.0.0",
@@ -1298,9 +1300,9 @@
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-federated": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.5.4.tgz",
-      "integrity": "sha512-ndA/wI5t5vEmrCz+WJI1UsVy87Zx4LDMdgo5QUv1ZvQJLsj9PegTSrt17pBHJlNYAcAlIUcY9zp3xFWpHmCX8A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.6.0.tgz",
+      "integrity": "sha512-OA7o+8ho6myGC/RRZZZpZcKm0cwM4zL0ASlV3qmgzx7NvFfFCaZHf+y5rImfYzNM/KpTSREBYl2BLD0hccCE2Q==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "asynciterator": "^2.0.1",
@@ -1310,19 +1312,20 @@
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-file": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-file/-/actor-rdf-resolve-quad-pattern-file-1.5.4.tgz",
-      "integrity": "sha512-Hrozfm5UadDO03PKoKnljnfWHmhy5tB1W1pjc2IRmPZqyeE6Kfw6atP/7DwK4DN2HRvtOP3mmtlbxKO4gobOjA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-file/-/actor-rdf-resolve-quad-pattern-file-1.6.0.tgz",
+      "integrity": "sha512-+XB9FA8/P8+3dQEsPl58pHb+TjTmPRiOh0194Vi6sXmthNzLySON4/wEd4AhgX4wL7Iemm++bTIq511CDL2Rew==",
       "requires": {
         "asynciterator": "^2.0.1",
+        "lru-cache": "^5.1.1",
         "n3": "^1.0.0",
         "rdf-string": "^1.3.1"
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.5.4.tgz",
-      "integrity": "sha512-Kgrf2EN3QY1DKMeldLM0c8L+zJt4VQCj34HiHFns4XZCZ/GrdRdG8mQBnyiBIAn8iJD3Nm/c5syqBV0X7+9/yw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.6.0.tgz",
+      "integrity": "sha512-+sPPwcbYiMYWonvGjd6gQ0UffAtFfcLWMFrNZ/9MS8Q/p8FiiE8lv+j5YU3xPue7fS4Vr3E3qdn2Nyb/j3KVVQ==",
       "requires": {
         "@comunica/utils-datasource": "^1.5.4",
         "@rdfjs/data-model": "^1.1.1",
@@ -1332,14 +1335,14 @@
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.5.4.tgz",
-      "integrity": "sha512-sABBl+cPQ49hhz84/IHzUScJeGywFLrpLUYXJACpmlAbe3ye9USesodZ2ljcxGNsT2V8XoKWmHYBkGm2nCfwAQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-1.6.0.tgz",
+      "integrity": "sha512-CpfawyPoeFn4nbDuMUmmcUetPql4cToeWB4DGNrWwcVyj0ijR/dg2yTK1+QYrOF547nYJT29Pnbegf6bwy308A=="
     },
     "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.5.4.tgz",
-      "integrity": "sha512-XpAV3cNvBJEcjTFwEMHotimQ7KpPVhjNv2BQIetGflcxE4uQxfdsrHv9BeUqwkLI4TA+/0cRoB/jNio52ysElg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.6.0.tgz",
+      "integrity": "sha512-AZYAuzHV3W9WHz2Tt+sdcNVLgimgquLd3NdjxAKHira0dgBrK40KjCt/HB6iDpLBaWKIyhOScB5nH9IX8D73XQ==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "asynciterator": "^2.0.1",
@@ -1350,9 +1353,9 @@
       }
     },
     "@comunica/actor-rdf-serialize-jsonld": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.5.4.tgz",
-      "integrity": "sha512-dhJFXy11W1UK7TWGwnL36a53Epvg6zJdj7y2gu4Ul0i1ArKrdDeLgw+eNkjWVJm0Pk2bqLHhm53K40BZks3Qug==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.6.0.tgz",
+      "integrity": "sha512-2YmT/Q084XlchWWKF1kzrY0h1lYTc8JVdufqsz5i/JP+kqBFAXzwRZb9obfTT/g0oNYTC4SFaETUSi2Pra45Og==",
       "requires": {
         "arrayify-stream": "^1.0.0",
         "jsonld": "^1.5.0",
@@ -1360,215 +1363,220 @@
       }
     },
     "@comunica/actor-rdf-serialize-n3": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.4.3.tgz",
-      "integrity": "sha512-bDJ5B22eaZo5Ny+Uoh+q7AQIev/x/icecesxOYBCnmOEq2qORLmkvJqzyEdfNtP8yUdP3JZnJ4rFoS0JaesO9g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-1.6.0.tgz",
+      "integrity": "sha512-beXKmf6CyhRUSd0KImL/DW66cvb4bim7aaVhYdJobYcOqxkIPtewbesgOuyWDSL6dYjT8qG+9N8LZgr+s0N9Iw==",
       "requires": {
         "n3": "^1.0.0",
         "rdf-string": "^1.3.1"
       }
     },
     "@comunica/actor-rdf-source-identifier-file-content-type": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-file-content-type/-/actor-rdf-source-identifier-file-content-type-1.5.1.tgz",
-      "integrity": "sha512-w5wek/kJb4ulncUfRSYFh3bbcMq1NyUssv6GLl48AZZPQ9PSBCHq4zb5iO8aXFF2Tm11kvuN46COsdlVy7gAYA=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-file-content-type/-/actor-rdf-source-identifier-file-content-type-1.6.0.tgz",
+      "integrity": "sha512-I9mHHvM2F3yTUR/OIWEMtRyUqUgHs6ZLRXFkZ5HdbdfbfWHtSS837CMam3zK+mvPWyEfclm5L+NtH19tIH7f9A=="
     },
     "@comunica/actor-rdf-source-identifier-hypermedia-qpf": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-hypermedia-qpf/-/actor-rdf-source-identifier-hypermedia-qpf-1.5.1.tgz",
-      "integrity": "sha512-L1OaaGfDS6pZqYg6Lr5woL51nmsQmZL5oah9Q8qZZzLMM/cGnFlH0rN+byhlLca8OJNsOR0GUjpgZhezgV7hnA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-hypermedia-qpf/-/actor-rdf-source-identifier-hypermedia-qpf-1.6.0.tgz",
+      "integrity": "sha512-0GvNx7n/JDDdODUlDtfW5gCv55YdEjoZb/J1LzPcKLNjTlmiybKZ2dt4gwvq67ckjbSRdLryar5Wn3IbkS/7+g==",
       "requires": {
         "stream-to-string": "^1.1.0"
       }
     },
     "@comunica/actor-rdf-source-identifier-sparql": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-sparql/-/actor-rdf-source-identifier-sparql-1.5.1.tgz",
-      "integrity": "sha512-i7yhFmppBhS3HlXow+BsjNZN7tAhiQDBpxLKTk4cTD7R/Dt9olxalP86rqsZMOh0PbvC0JwrMVaMrbRsHQlKnQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-sparql/-/actor-rdf-source-identifier-sparql-1.6.0.tgz",
+      "integrity": "sha512-dU/jWwvjIhyOcVGAFaq7ylfp7rqzcYA73k7TKlZKGqSiyMSs1eVfLeQQnyKHwcrUrjLlhHNE5DuOnfBnTfBcig=="
     },
     "@comunica/actor-sparql-parse-algebra": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.5.3.tgz",
-      "integrity": "sha512-75tma3F1qxzF4wVf0WcsZA6p6N7ixkQjRnf3bwKOFcNzqLrsEUmgGBjrOvpK0tR1ZW5CT2faAGwJ0tUnPEFV9w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.6.0.tgz",
+      "integrity": "sha512-aQNVJE0B7LCYKCfY6/6tgarwwWF1+ajIqrQITdQGl4O1hTkHX1By6JZ1d2IA2WyQ8NQEnR8TOK+EzkjpaXIywg==",
       "requires": {
         "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-sparql-parse-graphql": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.5.3.tgz",
-      "integrity": "sha512-Bhtw+40XwB9Ei8Gh/b0u8EI6iGDNOYHroEucheCKORKSq9bwvUm+dk2S3Gew1k4lNfmjzFOW0Lu8umU/IUCUQg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.6.0.tgz",
+      "integrity": "sha512-YYCtNycTZJdaN8oZmYgLprDslFSlOySjYgtZo3WCLPPUv4ULjI2lWMfNrEZXFYx1cuo9yMg6+vDhY06Tou4CYg==",
       "requires": {
         "graphql-to-sparql": "^1.5.0"
       }
     },
     "@comunica/actor-sparql-serialize-json": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.4.4.tgz",
-      "integrity": "sha512-LB0nlm/5dSD7XKoUslv4GnW3APWTaJXQvGlwhfTj2cdPZRHj+sq3ZR2ViyuD5LuLmqYIEnnSuaUIcZmX9UByBg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-json/-/actor-sparql-serialize-json-1.6.0.tgz",
+      "integrity": "sha512-+4EyE2sqz/y3hGxMdAu8xyZwwFoIOjBK+NmGCXFgbzv8bIyx28VhIKYS0yrikkrXbWnNtENk1aHBldxoY/frNA==",
       "requires": {
         "rdf-string": "^1.3.1"
       }
     },
     "@comunica/actor-sparql-serialize-rdf": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.4.4.tgz",
-      "integrity": "sha512-46/qsi2KS288yQkXLK2ToEe7Z7zWfFQqq5abpctgD9JL7V28i4YF6vlZR2RsqWHAmIgkRLfrJY7JRN3q5P7Xdw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-rdf/-/actor-sparql-serialize-rdf-1.6.0.tgz",
+      "integrity": "sha512-Kzj/nSK+VuQDhUWAnJZyJdXFrn6T29AF2BMJW+Szq+A1egW7bKexpD8MWxb8UX9iOJDEZj22m9YwEKBTsD4haw=="
     },
     "@comunica/actor-sparql-serialize-simple": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.4.4.tgz",
-      "integrity": "sha512-osP6Zp0a5Oe8AlJrLOwGcMKHuFb4+3+wjvrUUblorEMY4JRO+taLT/3pNoekoGTZa710SRBOmIqh1lTZvP12eQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-simple/-/actor-sparql-serialize-simple-1.6.0.tgz",
+      "integrity": "sha512-z4c4yd+rikFrE0oWLL2bbVu8eaG15TOUYLbTyIvDNaHhtwhkho3rx0e/iZq1IlkUXL/ZN3m6UtHE5s4lnTXIvw=="
     },
     "@comunica/actor-sparql-serialize-sparql-json": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.4.4.tgz",
-      "integrity": "sha512-XyjqyepaQc5qNN9WyL9pzLxf2wX3hcJBYwuhZEb9UametcMU32Re6EuCXRJLi3RpoEJ1+2GkM6ryzJkVcmn61Q=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-json/-/actor-sparql-serialize-sparql-json-1.6.0.tgz",
+      "integrity": "sha512-3yNaHRdFHIS9c1GIRhFyf+XdFTbzoj9p3H9bkHBrnjZ572pgBhvIJks2VdYIfSfkfAyyY9J5oJzGrM70ItQYHA=="
     },
     "@comunica/actor-sparql-serialize-sparql-xml": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.4.4.tgz",
-      "integrity": "sha512-LSN7aVhlxdNQ675GeTfoOgAYbFtopXX22GLrNznlHSUSI668JGFlqgNsy+3r2vCY9ftEyM4ufMk8F5SsYcc6ow==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-sparql-xml/-/actor-sparql-serialize-sparql-xml-1.6.0.tgz",
+      "integrity": "sha512-wqIXDIhmE4OXaNDP/d2vBh37Tvh/gMTJ5YtT0IRQkud1GKHsMwqZ0JkFa2mEYbmOncso15kl7FiHYCRyf3b++A==",
       "requires": {
         "xml": "^1.0.1"
       }
     },
     "@comunica/actor-sparql-serialize-stats": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.4.4.tgz",
-      "integrity": "sha512-37QQ/mimMJTgW5+xSIRBrULitqi4UFQhQ/3mE8qY9P+I2JFgumODPkbZBqPIRb9TsLhqCijir5+SOchxSXMY/g=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-stats/-/actor-sparql-serialize-stats-1.6.0.tgz",
+      "integrity": "sha512-NKHPtu7sLOPosTWoxtZPPFZCgH4r8JnRF0do3rpl3AdI1Ocek9y7jbUsRWJXqt3C+U5G5VgwX594Rih5UyrO/A=="
     },
     "@comunica/actor-sparql-serialize-table": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.4.4.tgz",
-      "integrity": "sha512-QV+vYd0vKGFo/u727KfqQNBTskk7fH91tfD2JbUlRS7ASGhsKklGp1gm9ucEy7/yJfWh78Ck2dCPvL06fPMc0A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-table/-/actor-sparql-serialize-table-1.6.0.tgz",
+      "integrity": "sha512-9JCAENwTGYekODNI8Oj+KP2MYNNs3ilIW278rodMxbZKHXL2wBJR9etPMkd2VtVNJgm8flMAmIbteZoKAfqnHg==",
       "requires": {
         "rdf-terms": "^1.4.0"
       }
     },
     "@comunica/actor-sparql-serialize-tree": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.4.4.tgz",
-      "integrity": "sha512-fYLpLliP85L2hai7dE2Z6aJxdEikO4TYGwl9UyZ8P+qmITQ2125TKgRC2tSGR02om+eGwWnt0Yhx+DGwyP0VLQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-serialize-tree/-/actor-sparql-serialize-tree-1.6.0.tgz",
+      "integrity": "sha512-KZoaV+zX6z6vmgX7h8s5qQ47G81Cng6Svmb6I1jq4qjgy3lNTYs7pFEeNgXs2VNlni3Kg/EGgwhqwNwtUuVEOA==",
       "requires": {
         "sparqljson-to-tree": "^1.3.0"
       }
     },
     "@comunica/bus-context-preprocess": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.4.0.tgz",
-      "integrity": "sha512-5fNGyLXhCZSD6xf7V5AUWWGu3Vhj1Ga/TNZu6nCCLhFlxWzQvqnCBOGlAiVrWqLlzMp4HSJbtwLo6FUz6Zkzwg=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-1.6.0.tgz",
+      "integrity": "sha512-Vq1vng3dvZXuz0H2lzHLzX3SZXk1g2MvR4tMrR03WsnZ+gbpiLJqzOrDhpJH4tLvdJaDTRpDOSA4eSAsV26NJg=="
     },
     "@comunica/bus-http": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.5.1.tgz",
-      "integrity": "sha512-t/UeakUThpXutbgvAduMXD8VjdnHOcjF34QAuNuEE647q3LjrQLtYBAoJZUs8b47LtU2spXIrY0ho3IE9xADAQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.6.0.tgz",
+      "integrity": "sha512-tVlCu6VXEMw7TZsbKLm8oMgtX2DshYuQtZ5mggO60SOYxg02y04gBcCn+M6FFjFSDfKheVDHkgqlugZlUHb1og==",
       "requires": {
         "is-stream": "^1.1.0",
         "node-web-streams": "^0.2.2"
       }
     },
+    "@comunica/bus-http-invalidate": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-1.6.0.tgz",
+      "integrity": "sha512-J4GV2lMj5Pwzjl2I7oE0yjdicmHntk4hqwOzoAlx1bb0g3PE0Yq2+ew8B7bDwnsmHAfB6mH8xQUCB/oZWkbZyg=="
+    },
     "@comunica/bus-init": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.4.0.tgz",
-      "integrity": "sha512-NPjWh6x5w+EqMVC7Wy5hj2pRLEsRuxy+9IThBRrQhJCnrWxA6+iz06N+7Kcyfp5796ueCM60i5j4DgcCIQDk5Q=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.6.0.tgz",
+      "integrity": "sha512-R3V6H5pGOLgFSY/O+i8kNAsIfPq2IkmdKFQ2R7zU5P++FQrkgdTEY952v+CRo7k97hiaFCza08Vl7nhpaz5x1Q=="
     },
     "@comunica/bus-optimize-query-operation": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.5.0.tgz",
-      "integrity": "sha512-+75LI5G8Qu0PkxwwTWaMYlFJFbitMybSi8DOxezg0P+mGgO9tejcYUTsQeG+8Po3HhzAn3c/XXOxkOb70dqMgA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.6.0.tgz",
+      "integrity": "sha512-9ngNZ3P6wflM/X3WNuN8SG1vamZY96AQU3Wv+DsS4wdPWQwM3Mm9JNikXizH4RCgr8h8zfH+zIuJUgEz8YHS3A==",
       "requires": {
         "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/bus-query-operation": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.4.4.tgz",
-      "integrity": "sha512-0i4Q3c/RPLDbjvXqstQjaQhjSPGTqahpNNR0mGYbzQLkmtP0n7eH5IaBRxesCBWQZ3QyibbF0t1pqNGziZkrRg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-1.6.0.tgz",
+      "integrity": "sha512-LJWt1IRVng2EHSD4klDi89F3hsMYwm5DsvOfhOcqaeuIo6Ir+QE4mUH3ooYmyT1P3nJGW5S4Vz17vhxIW/V+AA==",
       "requires": {
         "asynciterator": "^2.0.1",
         "immutable": "^3.8.2"
       }
     },
     "@comunica/bus-rdf-dereference": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.4.0.tgz",
-      "integrity": "sha512-JnpiqJNuENjmDW3PWM86un/rzAJrHHXZfyrsz6gUnOR7UJolGgZgEm9vLfRBYrz4sF7ezrtl0UPF+VvJ7xdBeg=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference/-/bus-rdf-dereference-1.6.0.tgz",
+      "integrity": "sha512-PNsD7DOMIt0jfS5XdnA03btWKVcTEbkl7AE4X/mPYP/J28wGF0EbPRlhGHwv0bN/o8/ZHWwHYGpSBnA1jTWjtw=="
     },
     "@comunica/bus-rdf-dereference-paged": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.4.0.tgz",
-      "integrity": "sha512-tsDujGS8bKCyJBG96hSOyYaePx5x5IIdDRGCQHgSEoUDgwe0QaksSF5g2S1odJhqyLZ8F/YDhf4qIwZ/CJWWog=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-dereference-paged/-/bus-rdf-dereference-paged-1.6.0.tgz",
+      "integrity": "sha512-Kdx4i7FKv77g1HBKI/cYsobsQ+Z3K+tN4YuF+PqwHNDtwNEbRCGuAJ6hszVJRIUHG/FOg74qGtnB1AygbOHPew=="
     },
     "@comunica/bus-rdf-join": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.4.4.tgz",
-      "integrity": "sha512-Kuv2C9hKvo/blq9VxAdKWSjUGsdKP8Z4G/T2LxlbT5fmF531QQjHnrE4KtH/xUnMnzhUNfv1jvOqcCyzoDeiPw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-1.6.0.tgz",
+      "integrity": "sha512-euBBx7ZmpSLyIQ6r/vNpd7wyf3nRfYoP0ueHOX0OiahW0xyRITy6oUjTBrxFa4hkSfrldLZf6vW8Gl1Li4ygeA==",
       "requires": {
         "lodash.intersection": "^4.4.0",
         "lodash.union": "^4.6.0"
       }
     },
     "@comunica/bus-rdf-metadata": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.4.0.tgz",
-      "integrity": "sha512-kbfS/H7QUIpvJyJWUnT5dgMZLIbNlCICeybnRoSbNW2kLKlrwWww/pYKigkgn22J4t32Wf+WYuIjX8X/K5sG8Q=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-1.6.0.tgz",
+      "integrity": "sha512-UIDpQilXGhyS3YLh4OjDx/r2ot4i4zlWk6vDR84n5STh/mYqguI/2FE8zGPQXRJscFPtm9GM1QduCyM42Zu+Ww=="
     },
     "@comunica/bus-rdf-metadata-extract": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.4.0.tgz",
-      "integrity": "sha512-dzXE6LTwpSFlBFtagHRX7+xLs6DoaDi74BTw5YCH3tjfWJUirRNFPXq1L3mwoEifuBSrsMKK6uQKw7fn5YB+0A=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-1.6.0.tgz",
+      "integrity": "sha512-yfuR1UKCrkNDSwCc+dFFPg3q5ABqnl8WjsfIQUScrlut9F+qO5o+IEN++6HZ3CrnvDOEqCXrQvf5VojKy2Xg2g=="
     },
     "@comunica/bus-rdf-parse": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.4.2.tgz",
-      "integrity": "sha512-xR7l4rH8nlXd5LdHrUsQ3UNTJlxOnZQLwrhC6ge9RTdwCKRkeQpzdRjTklSml/IZeIdiw6iFY5uT3bY/6j4TvA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-1.6.0.tgz",
+      "integrity": "sha512-b2m8LroOGSMpffOsVRVC2B6UzxFZIFy1tuhIiuBfPoNEQP6jiU9KqerloxS4UcHhNAeomVclpApwhuTI4RyyrA==",
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.4.0"
+        "@comunica/actor-abstract-mediatyped": "^1.6.0"
       }
     },
     "@comunica/bus-rdf-resolve-hypermedia": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.5.4.tgz",
-      "integrity": "sha512-WOYMfDyQdPLgrg43/nB7QfkJlfVCWOVIvlM8jDXfz3O3yg2WiQ6KnnHPXHMKfh0U0zTbIIzhjGkdqBAQzbSLLg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.6.0.tgz",
+      "integrity": "sha512-T/fk8i5dEXPR6/2NlRaqli69JVBOjKACV3Ll7MvgcfBaXkjIonlDYg13AVeuJcegjwjWQA+222aCElhmw2O8dw==",
       "requires": {
         "asynciterator": "^2.0.0",
         "asyncreiterable": "^1.1.1"
       }
     },
     "@comunica/bus-rdf-resolve-quad-pattern": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.5.4.tgz",
-      "integrity": "sha512-UKEMvY033et92wDgc7oR5JejzyNpSHxA+FL3HwwgyEMKf4rdXfl+/FwS6BcDRsmIKnoKxPa0SAn/ZXRIQTH5zg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.6.0.tgz",
+      "integrity": "sha512-tEZb0Vw8HcyYp5qmnWFdX/MW9ss0TECUmxEBTMZWf9lXWFThYGIDKuwfN8GOKlVHY8Ukq64j7rKlzBCtJMUQIQ==",
       "requires": {
         "asynciterator": "^2.0.1",
         "asyncreiterable": "^1.1.1"
       }
     },
     "@comunica/bus-rdf-serialize": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.4.0.tgz",
-      "integrity": "sha512-eEkdnh5clCI+AC8aFdRTOASUCGf0o1RryqRZfOT6hHWGGAUeTt+K1c3QSaltBPsubqj3v6NBMWrCj1/7Nhozfg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-1.6.0.tgz",
+      "integrity": "sha512-ZrDQUfyAUJ+OSu4QvAYHDh1nOMU9Ubn1H65bvTXtbfWsup+xq4OFuW0+97u+UUhnwwtyChN2j10t+FKkFNZJHw==",
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.4.0"
+        "@comunica/actor-abstract-mediatyped": "^1.6.0"
       }
     },
     "@comunica/bus-rdf-source-identifier": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-source-identifier/-/bus-rdf-source-identifier-1.5.1.tgz",
-      "integrity": "sha512-X2SjIG+d3EE8xgLJetUIQuSKGBPk28KO9SKNNqySSw3C3RBLJeYkK+1clUTqxE1tvBox55D6Fjv6A6kZJ8jszg=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-source-identifier/-/bus-rdf-source-identifier-1.6.0.tgz",
+      "integrity": "sha512-J9+DH/Ur5ToJCVGos0scPXS/RQz+0v9aeI/7iRFpk4XYweX24xl/e0m4pUcjgu3qXS20kjzNkAoHdU+3mlP8Zw=="
     },
     "@comunica/bus-sparql-parse": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.4.0.tgz",
-      "integrity": "sha512-IzyTYlf6FkkpTsvQWzu8e8WDGVgjfI90V8YWH+DEgn1PZsSIdD9u9wQBlIoWeZTA3w2CqbNwTnLtuDErxew6hA=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-parse/-/bus-sparql-parse-1.6.0.tgz",
+      "integrity": "sha512-+aYU08bFlV+55XMyofRmiWwPXx4EvKJzA+vi76fvEuL95Ea1tB8wun4T0yuoXuMEhNL5f8+GIu0LCms+vL6VYQ=="
     },
     "@comunica/bus-sparql-serialize": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.4.4.tgz",
-      "integrity": "sha512-cTokRdeLl6nNF3k4/PkzBrKVGoWjd8YnRyYH78SBehzkOHK2OlP4FG8s90A5SFksUQIVHM5xVPZ90Hmt6V35dA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-sparql-serialize/-/bus-sparql-serialize-1.6.0.tgz",
+      "integrity": "sha512-9JXGtS8Vls3mGxSLJfTpnnebpr7OfN7GTJLzVMg+MmVbksQQJoBg2Y6v+Fjtq0QkMwrYnBfWnlzyE3q/6Tm8wg==",
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^1.4.0"
+        "@comunica/actor-abstract-mediatyped": "^1.6.0"
       }
     },
     "@comunica/core": {
@@ -1581,14 +1589,22 @@
       }
     },
     "@comunica/logger-pretty": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.4.0.tgz",
-      "integrity": "sha512-8y7clI4JlaBMaD6WZGmLAhm4ms+Bq5mBnxzAXE6zjcU5yYAlRbBtxn9TbxJ1TqmYqPaS3tfI3m5VOX5fwOz0TQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-1.6.0.tgz",
+      "integrity": "sha512-rebJ2/PjyR5m+skFznp+LhAL8U/M0szPM3XD7JauVJ4remDszeD52t3R6XZOzlnZpn2eVEuiXHh2TKPoXoncWg=="
     },
     "@comunica/logger-void": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.4.0.tgz",
-      "integrity": "sha512-D1KWm0oKVIlUNBuwkQt4FOUUMoc6E8Qgd742hDI3GXDxW/sxgn59tPoqg1gdc5fE2/dJ0vPa1tnu+js+kYwQEQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-1.6.0.tgz",
+      "integrity": "sha512-HDnZ3Wfo9klpVCGYqc2JA1xei/wTyL3IqCaIa0e+sRoOM2tWPdGkG8DubhyJDFgiATX8tM6kW8W7sVIHkWP70A=="
+    },
+    "@comunica/mediator-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-1.6.0.tgz",
+      "integrity": "sha512-lowXP47ng3emu9sgo05BgOWC4uGm0PXuWHc4XojIktyHC+dRyWMVS/LFjBNJCxtsjUUZd30cjoqgUaibbduy8Q==",
+      "requires": {
+        "lodash": "^4.17.4"
+      }
     },
     "@comunica/mediator-combine-pipeline": {
       "version": "1.4.0",
@@ -1616,14 +1632,14 @@
       }
     },
     "@comunica/mediator-race": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.4.0.tgz",
-      "integrity": "sha512-C6ZuPNXJnwPqz61fk1c4dwvXZANkqN2sPC0ifgUMhlJWr/QvJkE8aI6/1EVZFHx5BQ5zOn54kYEum/DgJMCtkA=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-1.6.0.tgz",
+      "integrity": "sha512-KMLmwYdJKkAbadp87ke6kgUMTFc0ngLSnoVGmnFFR9LXqAKX7x+LuXIYu39QuNKBSCFyJbkcdgoifr+Oo/ZLmg=="
     },
     "@comunica/runner": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.4.4.tgz",
-      "integrity": "sha512-m2ccZome8l1v39gIi1r56bzNRkQaFPrmXI+v+VxsPy5761wSem4eQPD2f1FOGmm2rmLoA1L3unEeSm9pHYQvrA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-1.6.0.tgz",
+      "integrity": "sha512-vNWsSfJNNebQcMUuAM5t8jfdhSTZgD7fjf9qbw8peoJNV/uRDVgXuq//ANmeHXurnMu7htrKN/QnRqRJ9WeZPA==",
       "requires": {
         "componentsjs": "^3.2.0",
         "lodash.assign": "^4.2.0",
@@ -1631,11 +1647,11 @@
       }
     },
     "@comunica/runner-cli": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.4.4.tgz",
-      "integrity": "sha512-Dg7nl+1C1mMGnZADDxzoadsFEhaeAkG2JNGfYk0qMMKkpuXAEGL9rnznv/qLt+jarM1AD1xxKRnlEtnOwxy0Zw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-1.6.0.tgz",
+      "integrity": "sha512-ugdtj1tIPCRF+0QL9D0+rvaGdqwD5CtE/T0Ae/n03V9/ZzpuVTVXAtI/ReZqI/RmoBGepMkdF2PQqA72rT4JkA==",
       "requires": {
-        "@comunica/runner": "^1.4.4"
+        "@comunica/runner": "^1.6.0"
       }
     },
     "@comunica/utils-datasource": {
@@ -2358,6 +2374,15 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -2470,9 +2495,9 @@
       "dev": true
     },
     "componentsjs": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-3.2.0.tgz",
-      "integrity": "sha512-ruO5GneIIYtmi+Bg0Yj1Wqe+QBAeUGVjjn+u/TBNfqYZBoCnbHZV/gq8vm9bw6vWp5QBSjywy0PNNmgV71dxmA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-3.2.1.tgz",
+      "integrity": "sha512-/oBIU1aGFY/qgf/PEas554pHBaq9phkRgAASRG3yHFeYmFGmb21ab0bWPVgSYYMuchjcK4oPhZ6o6kFVICJPFA==",
       "requires": {
         "global-modules": "^1.0.0",
         "jsonld": "^0.4.11",
@@ -2555,6 +2580,18 @@
           "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "dev": true
         }
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "cross-spawn": {
@@ -2830,7 +2867,7 @@
     },
     "es6-promise": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
       "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
     },
     "escape-string-regexp": {
@@ -4200,6 +4237,15 @@
         }
       }
     },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "hash.js": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
@@ -4220,9 +4266,9 @@
       }
     },
     "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "requires": {
         "parse-passwd": "^1.0.0"
       }
@@ -5309,11 +5355,11 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonld": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.5.1.tgz",
-      "integrity": "sha512-/PFTIAwdF5BSWmPd+XMSheus+Att8oRtJT78ZR/ZMkmZL/dLm3RtNBC9BJmDaH4SyIZEik4pvvEJ3e/MgGBF/w==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.5.3.tgz",
+      "integrity": "sha512-fbgty6qs1UNmzHePUa+4wqZBbjdQN+XNs7bZ1kbp2e/ILIFTDHIuaUH9xrovTcrTfeBc/qbJ0aYpXvYOSRJZxg==",
       "requires": {
-        "rdf-canonize": "^1.0.1",
+        "rdf-canonize": "^1.0.2",
         "request": "^2.88.0",
         "semver": "^5.6.0",
         "xmldom": "0.1.19"
@@ -5540,6 +5586,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "mem": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
@@ -5627,7 +5683,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
@@ -5653,7 +5709,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -5662,7 +5718,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -5680,9 +5736,9 @@
       "dev": true
     },
     "n3": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.0.3.tgz",
-      "integrity": "sha512-IdcCNqb/1gj9fX63hoVEn3/Z1u9iLJiYLSpesmqT3+5UrxcYG5YldUP6T2okNRZKzyVdqz+I0PExGkWkz9gcZw=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.0.4.tgz",
+      "integrity": "sha512-iMHI7n3OsmMsUf6u9un6f8TCPgN1Zs6uKKcXrpTFUNXaswaOFk3H2/YuzuLE4T5Mhd+1haXAuufBFmsbRaULzw=="
     },
     "nan": {
       "version": "2.12.1",
@@ -5944,7 +6000,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         },
@@ -6293,9 +6349,9 @@
       }
     },
     "rdf-canonize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.0.1.tgz",
-      "integrity": "sha512-vQq6q7BIUwrVQijKRYdunxlodkn0Btjv2MnJ4S3rOUELsghq7fGuDaWuqBNbXca3KRbcRS6HwTIT2hJbJej2UA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.0.2.tgz",
+      "integrity": "sha512-drPKpTPfwrjkyqUFXnPEHj2JvYb54u2kMt+BbQb4vBvAORthLG/G8MBGs3kZZYcIzB6NyoZN9KvsupFV1Ti8VQ==",
       "requires": {
         "node-forge": "^0.7.6",
         "semver": "^5.6.0"
@@ -6364,7 +6420,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -6649,6 +6705,15 @@
         "glob": "^7.1.3"
       }
     },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
@@ -6783,6 +6848,15 @@
             "is-extendable": "^0.1.0"
           }
         }
+      }
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shebang-command": {
@@ -7025,26 +7099,20 @@
       }
     },
     "sparqlee": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-0.0.2.tgz",
-      "integrity": "sha512-4Gi30lGMgqfxuDUn0V4bFraA+Rk7auJQsW5uy3Pf0wBCv8BqePVdPHsfSUY+ycRDGcMx1hivvs83Oh8NMYTwRg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-0.1.0.tgz",
+      "integrity": "sha512-iLR9Vxky4ONoLX2rnvLg4tOtQVLXDE5b1qKH+jB8mrBUF2qlGDAic/PUF4w1nxQP3A+OlVcbJIWb1O/OmE0vrw==",
       "requires": {
         "@rdfjs/data-model": "^1.1.0",
         "@types/asynciterator": "^1.1.0",
         "@types/lodash": "^4.14.105",
         "@types/lodash.isequal": "^4.5.2",
-        "@types/node": "^10.11.4",
         "@types/rdf-js": "^2.0.1",
+        "create-hash": "^1.2.0",
         "immutable": "^3.8.2",
         "rdf-string": "^1.1.1",
-        "sparqlalgebrajs": "^1.1.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.12.26",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.26.tgz",
-          "integrity": "sha512-nMRqS+mL1TOnIJrL6LKJcNZPB8V3eTfRo9FQA2b5gDvrHurC8XbSA86KNe0dShlEL7ReWJv/OU9NL7Z0dnqWTg=="
-        }
+        "sparqlalgebrajs": "^1.1.0",
+        "uuid": "^3.3.2"
       }
     },
     "sparqljs": {
@@ -7346,7 +7414,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {
@@ -7762,7 +7830,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "lib"
   ],
   "dependencies": {
-    "@comunica/actor-init-sparql": "^1.5.0",
-    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.5.4",
-    "@comunica/actor-http-solid-auth-fetch": "^1.0.0"
+    "@comunica/actor-http-solid-auth-fetch": "^1.0.0",
+    "@comunica/actor-init-sparql": "^1.6.0",
+    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^1.6.0"
   },
   "peerDependencies": {
     "ldflex": "^2.0.0"


### PR DESCRIPTION
This is needed for exposing Comunica's new cache invalidation method.