### PR TITLE
Fix Comunica stream errors not being forwarded

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
     block-scoped-var: error,
     class-methods-use-this: off,
     complexity: error,
-    consistent-return: error,
+    consistent-return: off,
     curly: [ error, multi-or-nest, consistent ],
     default-case: error,
     dot-location: [ error, property ],


### PR DESCRIPTION
Some errors only occur in Comunica's bindingsStream, so there should be an `'error'` handler.
This PR will buffer errors until `readNextBinding` is called.

FYI, this was unrelated to https://github.com/comunica/comunica/issues/381.

Closes solid/query-ldflex#23